### PR TITLE
Add initial, baseline milestones page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,3 +10,4 @@
   - [`rate`](./rate.md)
   - [`effect`](./effect.md)
 - [Example](./example.md)
+- [Milestones](./milestones.md)

--- a/docs/src/milestones.md
+++ b/docs/src/milestones.md
@@ -1,0 +1,31 @@
+# Milestones
+
+## M1B
+
+### Galois
+
+**TBD:** link to Initial Platform Integration Plans
+
+### Uncharted
+
+[Initial integration plan](https://docs.google.com/presentation/d/1iVMypBEQutvqlZ0_kwYGy4Wy6fmoiWYqV3w8DHcnqe8/edit?ts=6009a8e8)
+
+## M2B
+
+### Galois
+
+**TBD:** link to Initial Report of AMIDOL as a Service with ASKE ecosystem
+
+### Uncharted
+
+Uncharted initial release of [codebase](https://github.com/uncharted-aske)
+
+## M3B
+
+### Galois
+
+Galois initial [code release](https://github.com/GaloisInc/ASKE-E)
+
+### Uncharted
+
+Uncharted has updated [their code repository](https://github.com/uncharted-aske)


### PR DESCRIPTION
Setting up the stub of our milestones listing page for docs. Will work with @ewdavis to fill in the missing parts so we can share this with DARPA.