### PR TITLE
aPRAM parsing

### DIFF
--- a/aske-e.cabal
+++ b/aske-e.cabal
@@ -29,6 +29,9 @@ library
                      , Language.ASKEE.APRAM.Translate
                      , Language.ASKEE.APRAM.Sample
                      , Language.ASKEE.APRAM.Print
+                     , Language.ASKEE.APRAM.GenLexer
+                     , Language.ASKEE.APRAM.GenParser
+                     , Language.ASKEE.APRAM.Lexer
 
                      , Language.ASKEE.ABM.Sample
                      , Language.ASKEE.ABM.Syntax

--- a/examples/apram/seird_q.py
+++ b/examples/apram/seird_q.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+import aPRAM_utils as utils
+from aPRAM_expressions import WN
+
+from aPRAM_settings import pop,sim
+
+pop.size = 100000
+delta = 0.001
+
+pop.reset()
+sim.reset()
+
+pop.make_column('health',np.zeros(pop.size))
+S = 1
+E = 2
+I = 3
+R = 4
+D = 5
+pop.make_column('quarantined', np.zeros(pop.size))
+Q = 1
+NQ = 2
+
+pop.make_param('beta', 0.3)
+
+# def p_transmission (beta):
+#     # Infectious agents -- those in cohort F -- can transmit infections
+#     # The probability of being an infectious agent is:
+#     p_infectious = pop.F.size / pop.size
+
+#     # Similarly, the probability of being a Susceptible agent is:
+#     p_susceptible = pop.S.size / pop.size
+
+#     # The probability that one meeting between two agents has one
+#     # infectious and one Susceptible is:
+#     p_one_potential_transmission = p_infectious * p_susceptible
+
+#     # Potential transmissions become actual transmissions with
+#     # probability beta:
+#     p_one_transmission = p_one_potential_transmission * beta
+
+#     # return both probability of transmission and its complement,
+#     # as Mods will need both
+
+#     return [p_one_transmission, 1 - p_one_transmission]
+
+pop.make_cohort('P', lambda: np.ones(pop.size).astype(bool))
+pop.make_cohort('S', lambda: pop.health.eq(S))
+pop.make_cohort('E', lambda: pop.health.eq(E))
+pop.make_cohort('I', lambda: pop.health.eq(I))
+pop.make_cohort('R', lambda: pop.health.eq(R))
+pop.make_cohort('D', lambda: pop.health.eq(D))
+pop.make_cohort('Q', lambda: pop.quarantined.eq(Q))
+pop.make_cohort(
+    'F',
+    lambda: np.logical_and(
+        pop.quarantined.eq(NQ),
+        np.logical_or(
+            pop.health.eq(E), 
+            pop.health.eq(I)
+        )
+    )
+)
+
+sim.make_mod(
+    name= 'initialize_attributes',
+    cohort = pop.P,
+    mods = [ 
+        [lambda **kwargs: pop.health.assign(S, **kwargs), lambda **kwargs: pop.quarantined.assign(NQ, **kwargs)] 
+    ],
+    prob_spec=lambda: [
+        1
+    ],
+    sim_phase='setup'
+)
+
+sim.make_mod(
+    name = 'seed_infections',
+    cohort = pop.P,
+    mods = [
+        [lambda **kwargs: pop.health.assign(E, **kwargs)],
+        [lambda **kwargs: pop.health.assign(S, **kwargs)],
+    ],
+    prob_spec = [
+        0.001,
+        0.999
+    ],
+    sim_phase= 'setup'
+    )
+
+sim.make_mod(
+    name= 'susceptible_to_exposed',
+    cohort = pop.S,
+    mods = [
+        [lambda **kwargs: pop.health.assign(E, **kwargs)],
+        []
+    ],
+    prob_spec = lambda: [
+        (pop.F.size / pop.size) * (pop.S.size / pop.size) * pop.beta.val,
+        1 - (pop.F.size / pop.size) * (pop.S.size / pop.size) * pop.beta.val,
+    ],
+    sim_phase = 'loop'
+)
+
+sim.make_mod(
+    name = 'exposed_to_next',
+    cohort = pop.E,
+    mods = [ 
+        [lambda **kwargs: pop.health.assign(I, **kwargs)],
+        [lambda **kwargs: pop.health.assign(R, **kwargs)],
+        [],
+    ],
+    prob_spec = [
+        0.2,
+        0.2,
+        0.6,
+    ],
+    sim_phase = 'loop'
+    )
+
+sim.make_mod(
+    name = 'infected_to_next',
+    cohort = pop.I,
+    mods = [ 
+        [lambda **kwargs: pop.health.assign(R, **kwargs)],
+        [lambda **kwargs: pop.health.assign(D, **kwargs)],
+        [], 
+    ],
+    prob_spec = [
+        0.1,
+        0.01,
+        0.89,
+    ],
+    sim_phase = 'loop'
+    )
+
+sim.make_mod(
+    name = 'quarantine',
+    cohort = pop.I,
+    mods = [ 
+        [lambda **kwargs: pop.quarantined.assign(Q, **kwargs), lambda **kwargs: pop.health.assign(D, **kwargs)],
+        []
+    ],
+    prob_spec = [0.1, 0.9],
+    sim_phase = 'loop'
+    )
+
+
+# ASKEE_STOP
+
+def probe_fn (day):
+    record = [day, sim.susceptible_to_exposed.mod_selector.probs[0]]
+    record.extend([c.size for c in [pop.S,pop.E,pop.I,pop.R,pop.D,pop.F,pop.Q]])
+    return record
+
+probe_labels = ['day','p','S','E','I','R','D','F','Q']
+
+
+sim.num_iterations  = 500
+sim.probe_labels    = probe_labels
+sim.probe_fn        = probe_fn
+
+sim.run_simulation()
+
+
+df1 = pd.DataFrame(sim.records,columns=probe_labels)
+
+print(df1)
+df1.S.plot(label='S')
+df1.E.plot(label='E')
+df1.I.plot(label='I')
+df1.R.plot(label='R')
+df1.D.plot(label='D')
+df1.Q.plot(label='Q')
+plt.legend()
+plt.show()

--- a/src/Language/ASKEE.hs
+++ b/src/Language/ASKEE.hs
@@ -23,6 +23,9 @@ import qualified Data.ByteString.Lazy.Char8 as B
 
 import           Language.ASKEE.APRAM.Print            ( printAPRAM )
 import           Language.ASKEE.APRAM.Translate        ( modelToAPRAM )
+import qualified Language.ASKEE.APRAM.GenLexer         as APL
+import qualified Language.ASKEE.APRAM.GenParser        as APP
+import           Language.ASKEE.APRAM.Syntax           ( APRAM(..) )
 import qualified Language.ASKEE.Check                  as Check
 import           Language.ASKEE.Convert
 import qualified Language.ASKEE.Core                   as Core
@@ -164,6 +167,20 @@ parseLatex file =
 loadLatex :: DataSource -> IO DiffEqs 
 loadLatex = parseLatex
 
+
+lexAPRAM :: DataSource -> IO [Located APL.Token]
+lexAPRAM file =
+  do  txt <- loadString file
+      case APL.lexAPRAM txt of
+        Right toks -> pure toks
+        Left err -> throwIO (ParseError $ "lexAPRAM: "<>err)
+
+parseAPRAM :: DataSource -> IO APRAM
+parseAPRAM file =
+  do  toks <- lexAPRAM file
+      case APP.parseAPRAM toks of
+        Right apram -> pure apram
+        Left err -> throwIO (ParseError $ "parseAPRAM: "<>err)
 -------------------------------------------------------------------------------
 
 data StratificationType = Demographic | Spatial

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -63,30 +63,26 @@ tokens :-
 "for"               { atomic For }
 "in"                { atomic In }
 "return"            { atomic Return }
-
 "math.log"          { atomic Log }
 "math.exp"          { atomic Exp }
--- "pop.size"          { atomic Size }
+
 "pop.reset()"       ;
 "sim.reset()"       ;
 
--- "pop.make_column"   { atomic MakeColumn }
--- "pop.make_param"    { atomic MakeParam }
--- "pop.make_cohort"   { atomic MakeCohort }
--- "pop." @ident ".eq" { cohortRef Eq }
 
-"pop" { atomic Pop }
-"."   { atomic Dot }
-"sim" { atomic Sim }
+"pop"               { atomic Pop }
+"."                 { atomic Dot }
+"sim"               { atomic Sim }
 
+"#".*"ASKEE_STOP".* { atomic EOF }
 "#".*               ;
 
-@string    { str }        
+@string             { str }        
 
-@ident  { ident }
+@ident              { ident }
 
-("from" .*)? "import" .* ("as" .*)? { atomic IGNORE }
-"rng".*"=".*"default_rng()" { atomic IGNORE }
+("from" .*)? "import" .* ("as" .*)?   { atomic IGNORE }
+"rng".*"=".*"default_rng()"           { atomic IGNORE }
 
 $white+     ;
 

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -49,6 +49,8 @@ tokens :-
 ","                 { atomic Comma }
 
 "lambda"            { atomic Lambda }
+"*"                 { atomic Star }
+"**"                { atomic StarStar }
 "not"               { atomic Not }
 "and"               { atomic And }
 "or"                { atomic Or }
@@ -63,7 +65,7 @@ tokens :-
 
 "math.log"          { atomic Log }
 "math.exp"          { atomic Exp }
-"pop.size"          { atomic Size }
+-- "pop.size"          { atomic Size }
 "pop.reset()"       ;
 "sim.reset()"       ;
 
@@ -76,16 +78,14 @@ tokens :-
 "."   { atomic Dot }
 "sim" { atomic Sim }
 
-"make_column"   { atomic MakeColumn }
-"make_param"    { atomic MakeParam }
-"make_cohort"   { atomic MakeCohort }
-"**" .* ")"     { atomic CloseP }
+"#".*               ;
 
 @string    { str }        
 
 @ident  { ident }
 
-("from" .*)? "import" .* ("as" .*)? ;
+("from" .*)? "import" .* ("as" .*)? { atomic IGNORE }
+"rng".*"=".*"default_rng()" { atomic IGNORE }
 
 $white+     ;
 
@@ -124,7 +124,7 @@ getState :: Alex AlexState
 getState = Alex (\s -> Right (s,s))
 
 lexAPRAM :: String -> Either String [Located Token]
-lexAPRAM s = runAlex s go
+lexAPRAM s = filter (\(Located _ _ t) -> t /= IGNORE) <$> runAlex s go
   where
   go :: Alex [Located Token]
   go =

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -2,10 +2,11 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Language.ASKEE.APRAM.GenLexer where
+module Language.ASKEE.APRAM.GenLexer ( lexAPRAM, Token(..) ) where
 
 import Prelude hiding (LT,GT,EQ)
-import Language.ASKEE.APRAM.Lexer
+import Language.ASKEE.APRAM.Lexer  ( Token(..), LogOp(..) )
+import Language.ASKEE.Lexer        ( Located(..) )
 
 }
 

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -1,0 +1,141 @@
+{
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Language.ASKEE.APRAM.GenLexer where
+
+import Prelude hiding (LT,GT,EQ)
+import Language.ASKEE.APRAM.Lexer
+
+}
+
+%wrapper "monad"
+
+$upper = [A-Z]
+$lower = [a-z]
+$digit = [0-9]
+$ws    = [\ ]
+$graphic = $printable # $white
+-- $quote = \" | \'
+
+
+@exp     = e [\+\-]? $digit+
+@real    = $digit+ (\. $digit+)? @exp?
+@ident   = [A-Za-z0-9_]+
+@lowerID = $lower @ident*
+@upperID = $upper @ident*
+@string  = (\" ($graphic # \")* \") | (\' ($graphic # \')* \')
+
+tokens :-
+
+@real               { real }
+"+"                 { atomic Plus }
+"-"                 { atomic Minus }
+"*"                 { atomic Times }
+"/"                 { atomic Divide }
+"="                 { atomic Assign }
+"<="                { atomic LTE }
+">="                { atomic GTE }
+"<"                 { atomic LT }
+">"                 { atomic GT }
+"=="                { atomic EQ }
+
+"("                 { atomic OpenP }
+")"                 { atomic CloseP }
+"["                 { atomic OpenB }
+"]"                 { atomic CloseB }
+
+":"                 { atomic Colon }
+","                 { atomic Comma }
+
+"lambda" .* ":"     { atomic Lambda }
+"not"               { atomic Not }
+"and"               { atomic And }
+"or"                { atomic Or }
+"if"                { atomic If }
+"then"              { atomic Then }
+"else"              { atomic Else }
+"True"              { bool True }
+"False"             { bool False }
+"for"               { atomic For }
+"in"                { atomic In }
+"return"            { atomic Return }
+
+"math.log"          { atomic Log }
+"math.exp"          { atomic Exp }
+"pop.size"          { atomic Size }
+"pop.reset()"       ;
+"sim.reset()"       ;
+
+-- "pop.make_column"   { atomic MakeColumn }
+-- "pop.make_param"    { atomic MakeParam }
+-- "pop.make_cohort"   { atomic MakeCohort }
+-- "pop." @ident ".eq" { cohortRef Eq }
+
+"pop" { atomic Pop }
+"."   { atomic Dot }
+"sim" { atomic Sim }
+
+"make_column"   { atomic MakeColumn }
+"make_param"    { atomic MakeParam }
+"make_cohort"   { atomic MakeCohort }
+"**" .* ")"     { atomic CloseP }
+
+@string    { str }        
+
+@ident (\. @ident)*  { ident }
+
+("from" .*)? "import" .* ("as" .*)? ;
+
+$white+     ;
+
+
+
+{
+type Action = AlexInput -> Int -> Alex Token
+
+real :: Action
+real (_,_,_,s) len = (pure . LitD . read . take len) s
+
+ident :: Action
+ident (_,_,_,s) len = (pure . Sym . take len) s
+
+bool :: Bool -> Action
+bool b = \_ _ -> pure $ LitB b
+
+str :: Action
+str (_,_,_,s) len = (pure . LitS . init . tail . take len) s
+
+cohortRef :: LogOp -> Action
+cohortRef op (_,_,_,s) len =
+  let res =
+        do  ("pop", a) <- lex (take len s)
+            (".", b) <- lex a
+            (cohort, _) <- lex b
+            pure cohort
+  in  case res of
+        [c] -> pure $ CohortExpr c op
+        r -> alexError $ "couldn't lex cohort reference \""<>s<>"\" ("<>show r<>")"
+
+atomic :: Token -> Action
+atomic tok = \_ _ -> pure tok
+
+getState :: Alex AlexState
+getState = Alex (\s -> Right (s,s))
+
+lexAPRAM :: String -> Either String [Located Token]
+lexAPRAM s = runAlex s go
+  where
+  go :: Alex [Located Token]
+  go =
+    do AlexPn _ line col <- alex_pos <$> getState
+       tok <- alexMonadScan
+       case tok of
+         EOF -> pure []
+         t ->
+           do rest <- go
+              pure (Located { locLine = line, locCol = col, locVal = t } : rest)
+
+alexEOF = pure EOF
+
+}

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -48,7 +48,7 @@ tokens :-
 ":"                 { atomic Colon }
 ","                 { atomic Comma }
 
-"lambda" .* ":"     { atomic Lambda }
+"lambda"            { atomic Lambda }
 "not"               { atomic Not }
 "and"               { atomic And }
 "or"                { atomic Or }
@@ -83,7 +83,7 @@ tokens :-
 
 @string    { str }        
 
-@ident (\. @ident)*  { ident }
+@ident  { ident }
 
 ("from" .*)? "import" .* ("as" .*)? ;
 

--- a/src/Language/ASKEE/APRAM/GenLexer.x
+++ b/src/Language/ASKEE/APRAM/GenLexer.x
@@ -4,10 +4,12 @@
 
 module Language.ASKEE.APRAM.GenLexer ( lexAPRAM, Token(..) ) where
 
-import Prelude hiding (LT,GT,EQ)
+import qualified Data.Text as Text
+
 import Language.ASKEE.APRAM.Lexer  ( Token(..), LogOp(..) )
 import Language.ASKEE.Lexer        ( Located(..) )
 
+import Prelude hiding (LT,GT,EQ)
 }
 
 %wrapper "monad"
@@ -95,13 +97,13 @@ real :: Action
 real (_,_,_,s) len = (pure . LitD . read . take len) s
 
 ident :: Action
-ident (_,_,_,s) len = (pure . Sym . take len) s
+ident (_,_,_,s) len = (pure . Sym . Text.pack . take len) s
 
 bool :: Bool -> Action
 bool b = \_ _ -> pure $ LitB b
 
 str :: Action
-str (_,_,_,s) len = (pure . LitS . init . tail . take len) s
+str (_,_,_,s) len = (pure . LitS . Text.pack . init . tail . take len) s
 
 cohortRef :: LogOp -> Action
 cohortRef op (_,_,_,s) len =
@@ -111,7 +113,7 @@ cohortRef op (_,_,_,s) len =
             (cohort, _) <- lex b
             pure cohort
   in  case res of
-        [c] -> pure $ CohortExpr c op
+        [c] -> pure $ CohortExpr (Text.pack c) op
         r -> alexError $ "couldn't lex cohort reference \""<>s<>"\" ("<>show r<>")"
 
 atomic :: Token -> Action

--- a/src/Language/ASKEE/APRAM/GenParser.y
+++ b/src/Language/ASKEE/APRAM/GenParser.y
@@ -14,20 +14,35 @@ import Data.Text ( pack )
 }
 
 %name        parseAPRAM APRAM
+%name        parseMod Mod
+%name        parseActionSequence ActionSequence
+%name        parseAction Action
 %tokentype   { Located Token}
 %error       { parseError }
 %monad       { Either String }
 
 %token
 
-eq                  { Located _ _ (Sym "eq") }
-ne                  { Located _ _ (Sym "ne") }
-np                  { Located _ _ (Sym "np") }
-repeat              { Located _ _ (Sym "repeat") }
-bool                { Located _ _ (Sym "bool") }
-zeros               { Located _ _ (Sym "zeros") }
-ones                { Located _ _ (Sym "ones") }
-astype              { Located _ _ (Sym "astype") }
+eq                  { Located _ _ (Sym "eq")           }
+ne                  { Located _ _ (Sym "ne")           }
+np                  { Located _ _ (Sym "np")           }
+repeat              { Located _ _ (Sym "repeat")       }
+bool                { Located _ _ (Sym "bool")         }
+zeros               { Located _ _ (Sym "zeros")        }
+ones                { Located _ _ (Sym "ones")         }
+astype              { Located _ _ (Sym "astype")       }
+make_column         { Located _ _ (Sym "make_column")  }
+make_param          { Located _ _ (Sym "make_param")   }
+make_cohort         { Located _ _ (Sym "make_cohort")  }
+make_mod            { Located _ _ (Sym "make_mod")     }
+name                { Located _ _ (Sym "name")         }
+cohort              { Located _ _ (Sym "cohort")       }
+mods                { Located _ _ (Sym "mods")         }
+prob_spec           { Located _ _ (Sym "prob_spec")    }
+sim_phase           { Located _ _ (Sym "sim_phase")    }
+assign              { Located _ _ (Sym "assign")       }
+delta               { Located _ _ (Sym "delta") }
+reset               { Located _ _ (Sym "reset") }
 
 
 true                { Located _ _ (Lexer.LitB True)  }
@@ -69,12 +84,11 @@ in                  { Located _ _ In         }
 return              { Located _ _ Return     }
 log                 { Located _ _ Lexer.Log  }
 exp                 { Located _ _ Lexer.Exp  }
+star                { Located _ _ Star       }
+starstar            { Located _ _ StarStar   }
 pop                 { Located _ _ Pop        }
 sim                 { Located _ _ Sim        }
 size                { Located _ _ Size       }
-make_column         { Located _ _ MakeColumn }
-make_param          { Located _ _ MakeParam  }
-make_cohort         { Located _ _ MakeCohort }
 
 
 %left 'or'
@@ -87,11 +101,16 @@ make_cohort         { Located _ _ MakeCohort }
 
 %%
 
-APRAM                              
-  : Size Columns Params Cohorts       { ($1, $2, $3, $4) }
+opt(p)
+   :    { Nothing }
+   | p  { Just $1 }
 
-Size                               :: { Double }
-  : size '=' REAL                     { $3 }
+APRAM                              
+  : Size Columns Params Cohorts Mods       { ($1, $2, $3, $4, $5) }
+
+Size                               :: { (Double, Double) }
+  : pop '.' size '=' REAL
+    delta '=' REAL                    { ($5, $8) }
 
 Columns                            :: { Map String [(String, Double)] }
   : Column                            { uncurry Map.singleton $1 }
@@ -129,22 +148,22 @@ Cohorts                            :: { [Cohort] }
 
 Cohort                             :: { Cohort }
   : pop '.' make_cohort '(' 
-      STRING ',' lambda ':' pop '.' SYM '.' eq '(' 
+      STRING ',' LambdaDecl pop '.' SYM '.' eq '(' 
         SYM 
       ')' 
-    ')'                               { Cohort $5 (Is $11 $15) }
+    ')'                               { Cohort $5 (Is $10 $14) }
   | pop '.' make_cohort '(' 
-      STRING ',' lambda ':' pop '.' SYM '.' ne '(' 
+      STRING ',' LambdaDecl pop '.' SYM '.' ne '(' 
         SYM 
       ')' 
-    ')'                               { Cohort $5 (Syntax.Not $11 $15) }
+    ')'                               { Cohort $5 (Syntax.Not $10 $14) }
   | pop '.' make_cohort '(' 
-      STRING ',' lambda ':' np '.' repeat '(' 
+      STRING ',' LambdaDecl np '.' repeat '(' 
         true ',' size
       ')' 
     ')'                               { Cohort $5 All }
   | pop '.' make_cohort '(' 
-      STRING ',' lambda ':' np '.' ones '(' 
+      STRING ',' LambdaDecl np '.' ones '(' 
         size 
       ')' '.' astype '(' 
         bool 
@@ -152,19 +171,100 @@ Cohort                             :: { Cohort }
     ')'                               { Cohort $5 All }
 
 
+Mods                               :: { [(String, String, [ActionSequence], [ProbSpec], String)] }
+  : Mod                               { [$1] }
+  | Mods Mod                          { $2 : $1 }
+
+Mod                                :: { (String, String, [ActionSequence], [ProbSpec], String) }
+  : sim '.' make_mod '('
+      name '=' STRING ','
+      cohort '=' pop '.' SYM ','
+      mods '=' '['
+        ActionSequences
+      ']' ','
+      prob_spec '=' LambdaDecl '['
+        ProbSpecs
+      ']' ','
+      sim_phase '=' STRING ','
+    ')'                               { ($7, $13, $18, $25, $30) }
+
+ActionSequences                    :: { [ActionSequence] }
+  :                                   { [] }
+  | ActionSequences ActionSequence    { $2 : $1 }
+
+ActionSequence                     :: { ActionSequence }
+  : '[' Actions ']' opt(',')          { Actions $2 }
+  | '[' ']' opt(',')                  { Pass }
+
+Actions                            :: { [Syntax.Action] }
+  : Action                            { [$1] }
+  | Actions Action                    { $2 : $1 }
+
+Action                             :: { Syntax.Action }
+  : LambdaDecl pop '.' SYM '.' assign '(' 
+      SYM ',' starstar SYM 
+    ')' opt(',')                      { Syntax.Assign $4 $8 }
+
+LambdaDecl                         :: { () }
+  : lambda LambdaArgs ':'             { () }
+
+LambdaArgs                         :: { () }
+  :                                   { () }
+  | LambdaArgs LambdaArg              { () }
+  | LambdaArgs LambdaArg ','          { () }
+
+LambdaArg                          :: { () }
+  : SYM                               { () }
+  | '*' SYM                           { () }
+  | starstar SYM                      { () }
+
+ProbSpecs                          :: { [ProbSpec] }
+  :                                   { [] }
+  | ProbSpecs Exp                     { Probability $2 : $1 }
+  | ProbSpecs Exp ','                 { Probability $2 : $1 }
+
+
 Exp                                :: { Expr }
   : REAL                              { Expr.LitD $1 }
   | SYM                               { Expr.Var (pack $1) }
-  | SYM '.' Exp                       { undefined }
-  | size                              { undefined }
-  | SYM '(' 
-      Exp 
-    ')'                               { undefined }
+  | Exp '/' Exp                       { Expr.Div $1 $3 }
 
+Exp                                   :: { Expr }
+  : Exp '+' Exp                          { Add  $1 $3 }
+  | Exp '-' Exp                          { Sub  $1 $3 }
+  | Exp '*' Exp                          { Mul  $1 $3 }
+  | Exp '/' Exp                          { Div  $1 $3 }
+  | '-' Exp                              { Neg  $2 }
+  | 'exp' '(' Exp ')'                    { Exp  $3 }
+  | 'log' '(' Exp ')'                    { Log  $3 }
+  | Exp '>' Exp                          { GT  $1 $3 }
+  | Exp '>=' Exp                         { GTE $1 $3 }
+  | Exp '==' Exp                         { EQ  $1 $3 }
+  | Exp '<=' Exp                         { LTE $1 $3 }
+  | Exp '<' Exp                          { LT  $1 $3 }
+  | Exp 'and' Exp                        { And $1 $3 }
+  | Exp 'or'  Exp                        { Or  $1 $3 } 
+  | 'not' Exp                            { Not $2 }
+  | '(' Exp ')'                          { $2 }
+  | Var                                  { Var $1 }
+  | REAL                                 { LitD $1 }
+  | 'True'                               { LitB True }
+  | 'False'                              { LitB False }
+  | Exp 'if' Exp 'else' Exp              { If $3 $1 $5 }
+
+Var :: { Expr }
+  : SYM { Var $1 }
+  | pop '.' SYM '.' val { Var $3 }
+  | pop '.' SYM '.' size { Var $3 }
 
 {
 -- mkAPRAM :: Double -> Map String (String, Expr) -> Map String Expr -> [Cohort] -> [Mod] -> APRAM
 mkAPRAM = undefined
+
+mkMod :: String -> Cohort -> [ActionSequence] -> [ProbSpec] -> String -> Either String Mod
+mkMod name cohort actions probs phase
+  | length actions == length probs = Right $ Mod name cohort (zip actions probs) phase
+  | otherwise = Left $ "mod action and probability lists differ in length"
 
 parseError :: [Located Lexer.Token] -> Either String a
 parseError []     = Left $ "parse error at end of file"

--- a/src/Language/ASKEE/APRAM/GenParser.y
+++ b/src/Language/ASKEE/APRAM/GenParser.y
@@ -1,0 +1,131 @@
+{
+module Language.ASKEE.APRAM.GenParser where
+
+import Language.ASKEE.APRAM.GenLexer
+import Language.ASKEE.APRAM.Lexer as Lexer
+import Language.ASKEE.APRAM.Syntax
+
+import Language.ASKEE.Expr as Expr
+
+import qualified Data.Map as Map
+import Data.Map ( Map )
+
+import Data.Text ( pack )
+}
+
+%name        parseAPRAM APRAM
+%name        parseCohort Cohort
+%tokentype   { Located Token}
+%error       { parseError }
+%monad       { Either String }
+
+%token
+
+BOOL                { Located _ _ (Lexer.LitB $$)  }
+REAL                { Located _ _ (Lexer.LitD $$)  }
+STRING              { Located _ _ (LitS $$)  }
+SYM                 { Located _ _ (Sym $$)   }
+'+'                 { Located _ _ Plus       }
+'-'                 { Located _ _ Minus      }
+'*'                 { Located _ _ Times      }
+'/'                 { Located _ _ Divide     }
+'='                 { Located _ _ Lexer.Assign }
+'<='                { Located _ _ Lexer.LTE  }
+'>='                { Located _ _ Lexer.GTE  }
+'<'                 { Located _ _ Lexer.LT   }
+'>'                 { Located _ _ Lexer.GT   }
+'=='                { Located _ _ Lexer.EQ   }
+
+'('                 { Located _ _ OpenP      }
+')'                 { Located _ _ CloseP     }
+'['                 { Located _ _ OpenB      }
+']'                 { Located _ _ CloseB     }
+
+':'                 { Located _ _ Colon      }
+','                 { Located _ _ Comma      }
+'.'                 { Located _ _ Dot        }
+
+ceq                 { Located _ _ (Sym "eq") }
+
+lambda              { Located _ _ Lambda     }
+not                 { Located _ _ Lexer.Not  }
+and                 { Located _ _ Lexer.And  }
+or                  { Located _ _ Lexer.Or   }
+if                  { Located _ _ Lexer.If   }
+then                { Located _ _ Then       }
+else                { Located _ _ Else       }
+for                 { Located _ _ For        }
+in                  { Located _ _ In         }
+return              { Located _ _ Return     }
+log                 { Located _ _ Lexer.Log  }
+exp                 { Located _ _ Lexer.Exp  }
+pop                 { Located _ _ Pop        }
+sim                 { Located _ _ Sim        }
+size                { Located _ _ Size       }
+make_column         { Located _ _ MakeColumn }
+make_param          { Located _ _ MakeParam  }
+make_cohort         { Located _ _ MakeCohort }
+
+
+%left 'or'
+%left 'and'
+%nonassoc '<' '<=' '==' '>=' '>'
+%nonassoc 'if' 'then' 'else'
+%right 'not'
+%left '+' '-'
+%left '*' '/'
+
+%%
+
+APRAM                              :: { APRAM }
+  : size Columns Params Cohorts       { mkAPRAM $1 $2 $3 $4 undefined }
+
+
+Columns                            :: { Map String [(String, Double)] }
+  : Column                            { uncurry Map.singleton $1 }
+  | Columns Column                    { uncurry Map.insert $2 $1 }
+
+Column                             :: { (String, [(String, Double)]) }
+  : pop '.' make_column '(' STRING ',' Exp ')' Statuses { ($5, $9) }
+
+
+Statuses                           :: { [(String, Double)] }
+  : Status                            { [$1] }
+  | Statuses Status                   { $2 : $1 }
+
+Status                             :: { (String, Double) }
+  : SYM '=' REAL                      { ($1, $3) }
+
+
+Params                             :: { Map String Expr }
+  : Param                             { uncurry Map.singleton $1 }
+  | Params Param                      { uncurry Map.insert $2 $1 }
+  
+Param                              :: { (String, Expr) }
+  : make_param '(' STRING ',' Exp ')' { ($3, $5) }
+
+
+Cohorts                            :: { [Cohort] }
+  : Cohort                            { [$1] }
+  | Cohorts Cohort                    { $2 : $1 }
+
+Cohort                             :: { Cohort }
+  : pop '.' make_cohort '(' STRING ',' lambda ':' pop '.' SYM '.' ceq '(' SYM ')' ')' { Cohort $5 (Is $11 $15) }
+
+
+Exp                                :: { Expr }
+  : REAL                              { Expr.LitD $1 }
+  | SYM                               { Expr.Var (pack $1) }
+  | SYM '.' Exp                       { undefined }
+  | SYM '(' Exp ')'                   { undefined }
+
+
+{
+-- mkAPRAM :: Double -> Map String (String, Expr) -> Map String Expr -> [Cohort] -> [Mod] -> APRAM
+mkAPRAM = undefined
+
+parseError :: [Located Lexer.Token] -> Either String a
+parseError []     = Left $ "parse error at end of file"
+parseError (t:ts) = Left $ "parse error at line " ++ show (locLine t) ++ ", col " ++ show (locCol t) ++ " (" ++ show t ++ ")"
+
+}

--- a/src/Language/ASKEE/APRAM/Lexer.hs
+++ b/src/Language/ASKEE/APRAM/Lexer.hs
@@ -54,11 +54,13 @@ data Token = EOF
   | For
   | In
   | Return
-
-  deriving Show
+  | Star
+  | StarStar
+  | IGNORE
+  deriving (Eq, Show)
 
 data LogOp =
     Eq
   | Lt
   | Gt
-  deriving Show
+  deriving (Eq, Show)

--- a/src/Language/ASKEE/APRAM/Lexer.hs
+++ b/src/Language/ASKEE/APRAM/Lexer.hs
@@ -1,12 +1,14 @@
 module Language.ASKEE.APRAM.Lexer where
 
+import Data.Text ( Text )
+
 import Prelude hiding ( GT, EQ, LT )
 
 data Token = EOF
-  | Sym String
+  | Sym Text
   | LitD Double
   | LitB Bool 
-  | LitS String
+  | LitS Text
   | OpenP
   | CloseP
   | OpenB
@@ -22,10 +24,10 @@ data Token = EOF
   | MakeParam
   | MakeCohort
   | MakeMod
-  | CohortExpr String LogOp
-  | ParamVal String
-  | CohortSize String
-  | ColumnAssign String
+  | CohortExpr Text LogOp
+  | ParamVal Text
+  | CohortSize Text
+  | ColumnAssign Text
   | Plus
   | Minus
   | Times

--- a/src/Language/ASKEE/APRAM/Lexer.hs
+++ b/src/Language/ASKEE/APRAM/Lexer.hs
@@ -1,0 +1,64 @@
+module Language.ASKEE.APRAM.Lexer where
+
+import Prelude hiding ( GT, EQ, LT )
+
+data Located a = Located
+  { locLine :: Int
+  , locCol :: Int
+  , locVal :: a
+  }
+  deriving Show
+
+data Token = EOF
+  | Sym String
+  | LitD Double
+  | LitB Bool 
+  | LitS String
+  | OpenP
+  | CloseP
+  | OpenB
+  | CloseB
+  | Comma
+  | Colon
+  | Lambda
+  | Log
+  | Exp
+  | Dot
+  | Size
+  | MakeColumn
+  | MakeParam
+  | MakeCohort
+  | MakeMod
+  | CohortExpr String LogOp
+  | ParamVal String
+  | CohortSize String
+  | ColumnAssign String
+  | Plus
+  | Minus
+  | Times
+  | Divide
+  | Assign
+  | If
+  | Then
+  | Else
+  | GT
+  | GTE
+  | EQ
+  | LTE
+  | LT
+  | And
+  | Or
+  | Not
+  | Pop
+  | Sim
+  | For
+  | In
+  | Return
+
+  deriving Show
+
+data LogOp =
+    Eq
+  | Lt
+  | Gt
+  deriving Show

--- a/src/Language/ASKEE/APRAM/Lexer.hs
+++ b/src/Language/ASKEE/APRAM/Lexer.hs
@@ -2,13 +2,6 @@ module Language.ASKEE.APRAM.Lexer where
 
 import Prelude hiding ( GT, EQ, LT )
 
-data Located a = Located
-  { locLine :: Int
-  , locCol :: Int
-  , locVal :: a
-  }
-  deriving Show
-
 data Token = EOF
   | Sym String
   | LitD Double

--- a/src/Language/ASKEE/APRAM/Syntax.hs
+++ b/src/Language/ASKEE/APRAM/Syntax.hs
@@ -1,12 +1,13 @@
 module Language.ASKEE.APRAM.Syntax where
 
 import Data.Map ( Map )
+import Data.Text ( Text, unpack )
 
 import Language.ASKEE.Expr ( Expr )
   
 data APRAM = APRAM
   { apramAgents   :: Int
-  , apramParams   :: Map String Expr
+  , apramParams   :: Map Text Expr
   , apramStatuses :: Map Column [Status]
   , apramCohorts  :: [Cohort]
   , apramMods     :: [Mod]
@@ -14,15 +15,15 @@ data APRAM = APRAM
   deriving Show
 
 data Mod = Mod
-  { modName    :: String 
+  { modName    :: Text 
   , modCohort  :: Cohort
   , modActions :: [(ActionSequence, ProbSpec)]
-  , modPhase   :: String
+  , modPhase   :: Text
   }
   deriving Show
 
 data Cohort = Cohort
-  { cohortName :: String 
+  { cohortName :: Text 
   , cohortExpr :: CohortExpr
   }
   deriving (Eq, Show)
@@ -50,8 +51,8 @@ data ProbSpec =
   | Unknown
   deriving (Show, Eq)
 
-type Column = String
-type Status = String
+type Column = Text
+type Status = Text
 
 instance Show Action where
-  show (Assign _ status) = "Assign_status_"<>status<>"_to"
+  show (Assign _ status) = "Assign_status_"<>unpack status<>"_to"

--- a/src/Language/ASKEE/APRAM/Translate.hs
+++ b/src/Language/ASKEE/APRAM/Translate.hs
@@ -97,6 +97,8 @@ eventsToMods columnName = map eventToMod
         Expr.Add (Expr.Var v') (Expr.LitD 1) | v == v' -> Just v'
         _ -> Nothing
 
+-------------------------------------------------------------------------------
+
 apramToModel :: APRAM -> Double -> Model
 apramToModel APRAM{..} delta = Model "foo" (letDecs ++ stateDecs) (concatMap modToEvents apramMods)
   where

--- a/src/Language/ASKEE/APRAM/Translate.hs
+++ b/src/Language/ASKEE/APRAM/Translate.hs
@@ -125,7 +125,8 @@ apramToModel APRAM{..} delta = Model "foo" (letDecs ++ stateDecs) (concatMap mod
       [ Let (pack t) e
       | (t, e) <- Map.toList apramParams
       ] ++
-      [ Let "delta" (Expr.LitD delta) ]
+      [ Let "delta" (Expr.LitD delta)
+      , Let "size" (Expr.LitD $ fromIntegral apramAgents) ]
   
     -- Generate every possible combination, Cartesian-product style, of `b`s, 
     -- propagating their `a` tags
@@ -176,7 +177,7 @@ apramToModel APRAM{..} delta = Model "foo" (letDecs ++ stateDecs) (concatMap mod
     asRate thisProbSpec passProbSpec =
       case (thisProbSpec, passProbSpec) of
         (Rate r, _) -> r
-        (Probability tp, Probability pp) -> Expr.Neg ((tp `Expr.Mul` Expr.Log pp) `Expr.Div` (Expr.LitD delta `Expr.Mul` (Expr.LitD 1 `Expr.Sub` pp)))
+        (Probability tp, Probability pp) -> Expr.Neg ((tp `Expr.Mul` Expr.Log pp) `Expr.Div` (Expr.Var "delta" `Expr.Mul` (Expr.LitD 1 `Expr.Sub` pp)))
         _ -> undefined
 
     mkEvent :: (String, [Action], Expr.Expr, State) -> Event
@@ -196,7 +197,7 @@ apramToModel APRAM{..} delta = Model "foo" (letDecs ++ stateDecs) (concatMap mod
               ]
 
         stateName = mkStateName state
-        scale = Expr.Var stateName `Expr.Div` Expr.LitD (fromIntegral apramAgents)
+        scale = Expr.Var stateName `Expr.Div` Expr.Var "size"
 
 -- Invariant: every APRAM column accounted for
 type State = Map Column Status


### PR DESCRIPTION
Implement lexing and parsing of aPRAM models written in Python. 

This iteration's philosophy isn't to parse Python, but to parse what we understand a series of aPRAM declarations to look like. Should future iterations seek to parse arbitrary Python and lens down to the desired AST, it may allow for more leeway in how aPRAMs are written (in Python) than we allow now.