### PR TITLE
Add gromet upload support

### DIFF
--- a/app/donu/ModelStorage.hs
+++ b/app/donu/ModelStorage.hs
@@ -33,6 +33,7 @@ initStorage = mapM_ make dirs
               , DiffEqs
               , ReactionNet
               , LatexEqnarray
+              , Gromet
               ]
       ]
 
@@ -78,6 +79,7 @@ formatLocation mt =
     ReactionNet   -> "rnet"
     DiffEqs       -> "deq"
     LatexEqnarray -> "latex"
+    Gromet        -> "gromet"
 
 baseDirectory :: FilePath
 baseDirectory = "modelRepo"

--- a/app/donu/Schema.hs
+++ b/app/donu/Schema.hs
@@ -130,7 +130,12 @@ instance HasSpec FitCommand where
 
         pure FitCommand {..}
 
-data ModelType = AskeeModel | DiffEqs | ReactionNet | LatexEqnarray
+data ModelType = 
+    AskeeModel 
+  | DiffEqs 
+  | Gromet
+  | ReactionNet
+  | LatexEqnarray
   deriving (Show, Eq)
 
 data ModelDef =
@@ -158,6 +163,7 @@ instance HasSpec ModelType where
          <!> (jsAtom "diff-eqs" $> DiffEqs)
          <!> (jsAtom "reaction-net" $> ReactionNet)
          <!> (jsAtom "latex-eqnarray" $> LatexEqnarray)
+         <!> (jsAtom "gromet" $> Gromet)
 
 instance JS.ToJSON ModelType where
   toJSON mt =
@@ -166,6 +172,7 @@ instance JS.ToJSON ModelType where
       DiffEqs -> JS.String "diff-eqs"
       ReactionNet -> JS.String "reaction-net"
       LatexEqnarray -> JS.String "latex-eqnarray"
+      Gromet -> JS.String "gromet"
 
 
 dataSource :: ValueSpec DataSource


### PR DESCRIPTION
Gromet checking is very limited at the moment, and relies on `jq` being
installed on the host machine, as it's used as a JSON validator to
proxy for the full-scale gromet validation we currently lack.