### PR TITLE
Add `exposure` sessions to Donu

### DIFF
--- a/app/donu/ExposureSession.hs
+++ b/app/donu/ExposureSession.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+module ExposureSession where
+
+import Snap.Snaplet.Session
+
+import Control.Monad.State
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.Time (UTCTime)
+import qualified Data.Serialize as S
+
+import Web.ClientSession
+import Data.ByteString
+import Data.Time.Clock (getCurrentTime)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Control.Concurrent (MVar, modifyMVar_, newMVar, readMVar)
+
+import Snap (Snap, SnapletInit, makeSnaplet, Handler, liftSnap)
+
+data ExposureSessionManager st = ExposureSessionManager
+  { stateMap        :: MVar (Map Text st)
+  , timeoutMap      :: MVar (Map Text UTCTime)
+  , key             :: Key
+  , cookieName      :: ByteString
+  , timeout         :: Int
+  , session         :: Maybe ExposureSession
+  , randomNumGen    :: RNG
+  }
+
+newtype ExposureSession = ExposureSession
+  { esToken :: Text }
+  deriving (Eq, Show)
+
+newtype Payload = Payload ByteString
+  deriving (Eq, Show, Ord, S.Serialize)
+
+instance S.Serialize ExposureSession where
+  put (ExposureSession t) = S.put (encodeUtf8 t)
+  get = ExposureSession . decodeUtf8 <$> S.get
+
+initExposureSessionManager :: FilePath -> ByteString -> Int -> SnapletInit b (ExposureSessionManager s)
+initExposureSessionManager keyPath c t =
+  makeSnaplet
+    "ExposureSession"
+    "A snaplet providing sessions for the Exposure REPL"
+    Nothing $
+    liftIO $
+      do k <- getKey keyPath
+         rng <- liftIO mkRNG
+         sm <- newMVar mempty
+         tm <- newMVar mempty
+         return $! ExposureSessionManager sm tm k c t Nothing rng
+
+cullOldSessions :: Handler b (ExposureSessionManager s) ()
+cullOldSessions =
+  do esm <- get
+     to  <- liftIO $ readMVar (timeoutMap esm)
+     -- If someone adds more then we'll miss them here,
+     -- but that's ok
+     forM_ (Map.toList to) $ \(token, time)  ->
+       do timedout <- checkTimeout (Just (timeout esm)) time
+          when timedout
+            (liftSnap $ deleteSession (ExposureSession token) esm)
+     put esm { session = Nothing }
+
+getExposureSessionState :: Handler b (ExposureSessionManager s) (Maybe s)
+getExposureSessionState =
+  do esm <- get
+     esm' <- liftSnap $ loadSession esm
+     put esm'
+     case session esm' of
+       Just s ->
+         do sm <- liftIO $ readMVar (stateMap esm')
+            return $ Map.lookup (esToken s) sm
+       Nothing ->
+         return Nothing
+
+putExposureSessionState :: st -> Handler b (ExposureSessionManager st) ()
+putExposureSessionState st =
+  do esm <- get
+     esm' <- liftSnap $ loadSession esm
+     put esm'
+     case session esm' of
+       Just s ->
+         liftIO $ modifyMVar_ (stateMap esm') (pure . Map.insert (esToken s) st)
+       Nothing ->
+         return ()
+
+mkExposureSession :: RNG -> IO ExposureSession
+mkExposureSession rng =
+  ExposureSession <$> liftIO (mkCSRFToken rng)
+
+pokeSession :: ExposureSessionManager st -> Snap (ExposureSessionManager st)
+pokeSession esm =
+  case session esm of
+    Just s ->
+      do now <- liftIO getCurrentTime
+         liftIO $ modifyMVar_ (timeoutMap esm) (pure . Map.insert (esToken s) now)
+         return esm
+    Nothing ->
+      return esm
+
+deleteSession :: ExposureSession -> ExposureSessionManager st -> Snap ()
+deleteSession s esm = liftIO $
+  do modifyMVar_ (timeoutMap esm) (pure . Map.delete (esToken s))
+     modifyMVar_ (stateMap esm) (pure . Map.delete (esToken s))
+     return ()
+
+loadSession :: ExposureSessionManager st -> Snap (ExposureSessionManager st)
+loadSession esm =
+  case session esm of
+    Just _  -> return esm
+    Nothing ->
+      do tk   <- getSecureCookie (cookieName esm) (key esm) (Just $ timeout esm)
+         case tk of
+           -- We have a thing
+           Just (Payload (S.decode -> Right s)) ->
+             pokeSession esm { session = Just s }
+           _ ->
+             -- New session
+             do sess <- liftIO $ mkExposureSession (randomNumGen esm)
+                setSecureCookie (cookieName esm) Nothing (key esm) (Just $ timeout esm) (Payload (S.encode sess))
+                pokeSession esm { session = Just sess }
+
+commitExposureSession :: ExposureSessionManager st -> Snap ()
+commitExposureSession esm =
+  do pl <- case session esm of
+             Just s  ->
+               do void $ pokeSession esm
+                  return $ Payload (S.encode s)
+             Nothing ->
+               do sess <- liftIO $ mkExposureSession (randomNumGen esm)
+                  void $ pokeSession esm { session = Just sess }
+                  return $ Payload (S.encode sess)
+     setSecureCookie (cookieName esm) Nothing (key esm) (Just $ timeout esm) pl

--- a/app/donu/Main.hs
+++ b/app/donu/Main.hs
@@ -11,6 +11,7 @@ import qualified Web.ClientSession as ClientSession
 
 import qualified Data.Text as Text
 import qualified Data.Aeson as JS
+import           Data.Maybe (fromMaybe)
 
 import qualified Snap
 
@@ -21,12 +22,12 @@ import           Language.ASKEE.Exposure.GenParser (parseExposureStmt)
 
 import           Schema
 import           ExposureSession
-import Data.Maybe (fromMaybe)
 
 -- Snaplet Definition ---------------------------------------------------------
 
 newtype Donu sim = Donu
  { _exposureSessions :: Snap.Snaplet (ExposureSessionManager sim)
+   -- ^ Snaplet implementing Exposure REPL sessions
  }
 
 makeLenses ''Donu
@@ -58,7 +59,6 @@ initDonu =
                runHandler a
            <|> do Snap.modifyResponse
                    (Snap.setResponseStatus 400 "Bad request")
-                  -- Snap.writeText $ Text.pack "ASDF")
           Left err ->
             do  Snap.writeText $ Text.pack err
                 Snap.modifyResponse (Snap.setResponseStatus 400 "Bad request")
@@ -182,7 +182,7 @@ handleRequest r =
                Right (env', displays, effs) ->
                  do Snap.with exposureSessions $
                       putExposureSessionState env'
-                    succeed' (length displays, length effs)
+                    succeed' (length displays, length effs) -- TODO: Fill this in once `evalStmt` returns more stuff
 
     ResetExposureState _ ->
       do Snap.with exposureSessions $

--- a/app/donu/Main.hs
+++ b/app/donu/Main.hs
@@ -1,30 +1,62 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Main ( main ) where
 
-import Control.Monad.IO.Class ( liftIO )
-import Control.Exception      ( try, SomeException )
+import           Control.Applicative ((<|>))
+import           Control.Lens.TH
+import           Control.Lens (view)
+import           Control.Monad.IO.Class ( liftIO )
+import qualified Web.ClientSession as ClientSession
 
 import qualified Data.Text as Text
 import qualified Data.Aeson as JS
+import           Data.IORef (IORef, newIORef, readIORef)
+import           Data.Map.Strict (Map, findWithDefault)
+import           Data.Text (Text)
 
-import Language.ASKEE
-import Language.ASKEE.Exposure.GenLexer (lexExposure)
-import Language.ASKEE.Exposure.GenParser (parseExposureStmt)
+import qualified Snap
+import qualified Snap.Snaplet.Session as Session
+import qualified Snap.Snaplet.Session.Backends.CookieSession as Session
+
+import           Language.ASKEE
+import           Language.ASKEE.Exposure.GenLexer (lexExposure)
+import           Language.ASKEE.Exposure.GenParser (parseExposureStmt)
 import qualified Language.ASKEE.Exposure.Interpreter as Exposure
 
-import Schema
+import           Schema
 
-import qualified Snap.Core as Snap
-import           Snap.Http.Server ( quickHttpServe )
+-- Snaplet Definition ---------------------------------------------------------
 
-main :: IO ()
-main =
-  do  initStorage
-      quickHttpServe $
-        do  Snap.route [ ("/help", showHelp)
-                       , ("/", endpoint)
-                       ]
+data Donu sim = Donu
+ { _simulatorSessions :: Snap.Snaplet Session.SessionManager
+ , _simulatorState    :: IORef (Map Text sim)
+ }
+
+makeLenses ''Donu
+
+exposureState :: s -> Snap.Handler (Donu s) (Donu s) s
+exposureState emp =
+  do tk    <- Snap.with simulatorSessions Session.csrfToken
+     stRef <- view simulatorState
+     findWithDefault emp tk <$> liftIO (readIORef stRef)
+
+-------------------------------------------------------------------------------
+
+initDonu :: Snap.SnapletInit (Donu ()) (Donu ())
+initDonu =
+  Snap.makeSnaplet "donu" "donu" Nothing $
+    do sess <- Snap.nestSnaplet "sessions" simulatorSessions $
+                 Session.initCookieSessionManager
+                   ClientSession.defaultKeyFile -- TODO: Do we care about this?
+                   "exposure-env-id"
+                   Nothing -- TODO: Do we need to set a domain?
+                   Nothing -- TODO: We should probably set a timeout
+       Snap.addRoutes [ ("/help", showHelp)
+                      , ("/", endpoint)
+                      ]
+       m <- liftIO $ newIORef mempty
+       return $ Donu sess m
   where
     endpoint =
      do let limit = 8 * 1024 * 1024    -- 8 megs
@@ -32,37 +64,42 @@ main =
         body <- Snap.readRequestBody limit
         case JS.eitherDecode body of
           Right a ->
-            do  r <- liftIO $ try $ handleRequest a
-                case r of
-                  Right out ->
-                    do  let (code, msg) =
-                              case out of
-                                (FailureResult _) -> (400, "Error")
-                                _ -> (200, "OK")
-                        Snap.modifyResponse (Snap.setResponseStatus code msg)
-                        Snap.writeLBS (JS.encode out)
-                  Left err ->
-                    do  Snap.modifyResponse
-                                  (Snap.setResponseStatus 400 "Bad request")
-                        Snap.writeText $ Text.pack $ show (err :: SomeException)
+               runHandler a
+           <|> do Snap.modifyResponse
+                   (Snap.setResponseStatus 400 "Bad request")
+                  -- Snap.writeText $ Text.pack "ASDF")
           Left err ->
             do  Snap.writeText $ Text.pack err
                 Snap.modifyResponse (Snap.setResponseStatus 400 "Bad request")
-                -- showHelp
 
-showHelp :: Snap.Snap ()
+    runHandler r =
+      do out <- handleRequest r
+         let (code, msg) =
+               case out of
+                 (FailureResult _) -> (400, "Error")
+                 _ -> (200, "OK")
+         Snap.modifyResponse (Snap.setResponseStatus code msg)
+         Snap.writeLBS (JS.encode out)
+
+
+main :: IO ()
+main =
+  do initStorage
+     Snap.serveSnaplet Snap.defaultConfig initDonu
+
+showHelp :: Snap.Handler (Donu sim) (Donu sim) ()
 showHelp = Snap.writeLBS helpHTML
 
 --------------------------------------------------------------------------------
 
 
-handleRequest :: Input -> IO Result
+handleRequest :: Input -> Snap.Handler (Donu ()) (Donu ()) Result
 handleRequest r =
-  print r >>
+  liftIO (print r) >>
   case r of
     SimulateGSL SimulateGSLCommand{..} ->
       do  res <-
-            simulateModelGSL
+            liftIO $ simulateModelGSL
               (modelDefType simModelGSL)
               (modelDefSource simModelGSL)
               simStartGSL
@@ -73,7 +110,7 @@ handleRequest r =
 
     SimulateAJ SimulateAJCommand{..} ->
       do  res <-
-            simulateModelAJ
+            liftIO $ simulateModelAJ
               (modelDefType simModelAJ)
               (modelDefSource simModelAJ)
               simStartAJ
@@ -83,14 +120,15 @@ handleRequest r =
           succeed' res
 
     CheckModel CheckModelCommand{..} ->
-      do  model <- loadModelText (modelDefType checkModelModel) (modelDefSource checkModelModel)
-          checkResult <- checkModel' (modelDefType checkModelModel) model
+      do  model <- liftIO $ loadModelText (modelDefType checkModelModel) (modelDefSource checkModelModel)
+          checkResult <- liftIO $ checkModel' (modelDefType checkModelModel) model
           case checkResult of
             Nothing  -> succeed' ()
             Just err -> pure (FailureResult (Text.pack err))
 
     ConvertModel ConvertModelCommand{..} ->
       do  converted <-
+            liftIO $
             convertModelString
               (modelDefType convertModelSource)
               (modelDefSource convertModelSource)
@@ -99,6 +137,7 @@ handleRequest r =
 
     Fit FitCommand{..} ->
       do  (res, _) <-
+            liftIO $
             fitModelToData
               (modelDefType fitModel)
               fitData
@@ -108,43 +147,46 @@ handleRequest r =
           succeed' (FitResult res)
 
     GenerateCPP (GenerateCPPCommand ModelDef{..}) ->
-      do  cpp <- loadCPPFrom modelDefType modelDefSource
+      do  cpp <- liftIO $ loadCPPFrom modelDefType modelDefSource
           succeed' (Text.pack $ show cpp)
 
     Stratify StratifyCommand{..} ->
-        do  res <- stratifyModel (modelDefType stratModel) (modelDefSource stratModel) stratConnections stratStates stratType
+        do  res <- liftIO $ stratifyModel (modelDefType stratModel) (modelDefSource stratModel) stratConnections stratStates stratType
             succeed' res
 
-    ListModels _ -> succeed <$> listAllModelsWithMetadata
+    ListModels _ -> succeed <$> liftIO listAllModelsWithMetadata
 
     ModelSchemaGraph (ModelSchemaGraphCommand ModelDef{..}) ->
-      do  modelSource <- loadCoreFrom modelDefType modelDefSource
+      do  modelSource <- liftIO $ loadCoreFrom modelDefType modelDefSource
           case asSchematicGraph modelSource of
             Nothing -> pure (FailureResult "model cannot be rendered as a schematic")
             Just g -> succeed' g
 
     UploadModel UploadModelCommand{..} ->
-      do  mdef <- storeModel uploadModelType uploadModelName uploadModelSource
+      do  mdef <- liftIO $ storeModel uploadModelType uploadModelName uploadModelSource
           succeed' mdef
 
     GetModelSource GetModelSourceCommand{..} ->
-      do  modelString <- loadModelText (modelDefType getModelSource) (modelDefSource getModelSource)
+      do  modelString <- liftIO $ loadModelText (modelDefType getModelSource) (modelDefSource getModelSource)
           let result = getModelSource { modelDefSource = Inline modelString }
           succeed' result
 
     DescribeModelInterface (DescribeModelInterfaceCommand ModelDef{..}) ->
-      do  model <- loadModel modelDefType modelDefSource
+      do  model <- liftIO $ loadModel modelDefType modelDefSource
           let res = describeModelInterface model
           succeed' res
 
     ExecuteExposureCode (ExecuteExposureCodeCommand code) ->
-      pure $
       case lexExposure (Text.unpack code) >>= parseExposureStmt of
-        Left err   -> FailureResult $ Text.pack err
-        Right stmt -> undefined --succeed $ Exposure.interpretStmt stmt
+        Left err   ->
+          pure $ FailureResult $ Text.pack err
+        Right stmt ->
+          Session.withSession simulatorSessions $
+            do _state <- exposureState ()
+               return $ undefined -- succeed $ Exposure.interpretStmt stmt
   where
     succeed :: (JS.ToJSON a, Show a) => a -> Result
     succeed = SuccessResult
 
-    succeed' :: (JS.ToJSON a, Show a) => a -> IO Result
+    succeed' :: (JS.ToJSON a, Show a) => a -> Snap.Handler x x Result
     succeed' = pure . succeed

--- a/app/donu/Schema.hs
+++ b/app/donu/Schema.hs
@@ -39,6 +39,7 @@ data Input =
   | UploadModel UploadModelCommand
   | DescribeModelInterface DescribeModelInterfaceCommand
   | ExecuteExposureCode ExecuteExposureCodeCommand
+  | ResetExposureState ResetExposureStateCommand
     deriving Show
 
 instance HasSpec Input where
@@ -55,6 +56,7 @@ instance HasSpec Input where
          <!> (UploadModel <$> anySpec)
          <!> (DescribeModelInterface <$> anySpec)
          <!> (ExecuteExposureCode <$> anySpec)
+         <!> (ResetExposureState <$> anySpec)
 
 instance JS.FromJSON Input where
   parseJSON v =
@@ -442,3 +444,12 @@ instance HasSpec ExecuteExposureCodeCommand where
                     "Execute an Exposure command"
         executeExposureCode <- reqSection' "code" textSpec "The code to execute"
         pure ExecuteExposureCodeCommand{..}
+
+newtype ResetExposureStateCommand = ResetExposureStateCommand ()
+  deriving Show
+
+instance HasSpec ResetExposureStateCommand where
+  anySpec =
+    sectionsSpec "clear-exposure" $
+      do reqSection' "command" (jsAtom "clear-exposure-state") "Reset the current session's interpreter state"
+         pure $ ResetExposureStateCommand ()

--- a/aske-e.cabal
+++ b/aske-e.cabal
@@ -185,17 +185,20 @@ executable donu
                       , aeson
                       , aske-e
                       , bytestring
+                      , clientsession
                       , config-schema
                       , config-value
                       , containers
                       , directory
                       , filepath
+                      , lens
                       , pretty
                       , process
                       , scientific
                       , semigroupoids
                       , snap-core
                       , snap-server
+                      , snap
                       , text
                       , unordered-containers
                       , vector

--- a/aske-e.cabal
+++ b/aske-e.cabal
@@ -176,7 +176,8 @@ executable deca
 executable donu
   hs-source-dirs:       app/donu
   main-is:              Main.hs
-  other-modules:        HTML
+  other-modules:        ExposureSession
+                        HTML
                         Schema
                         SchemaGeneric
                         SchemaJS
@@ -185,6 +186,7 @@ executable donu
                       , aeson
                       , aske-e
                       , bytestring
+                      , cereal
                       , clientsession
                       , config-schema
                       , config-value
@@ -192,6 +194,7 @@ executable donu
                       , directory
                       , filepath
                       , lens
+                      , mtl
                       , pretty
                       , process
                       , scientific
@@ -200,6 +203,7 @@ executable donu
                       , snap-server
                       , snap
                       , text
+                      , time
                       , unordered-containers
                       , vector
 

--- a/client_session_key.aes
+++ b/client_session_key.aes
@@ -1,0 +1,1 @@
+#ÄIÌ‹9WDÚ{ãÄ3bÖë8œFUŠqºrÿ£ý@›ª›É˜nD…I–iœ¢Õ]’ß6#‰á¥ŸJ‘åUãw€E4Ýb?nÂ’¤É°p£Y7CÆ¦Ð±ÈqK˜²

--- a/client_session_key.aes
+++ b/client_session_key.aes
@@ -1,1 +1,0 @@
-#ÄIÌ‹9WDÚ{ãÄ3bÖë8œFUŠqºrÿ£ý@›ª›É˜nD…I–iœ¢Õ]’ß6#‰á¥ŸJ‘åUãw€E4Ýb?nÂ’¤É°p£Y7CÆ¦Ð±ÈqK˜²

--- a/hie.yaml
+++ b/hie.yaml
@@ -21,6 +21,9 @@ cradle:
     - path: "app/donu/Schema.hs"
       component: "aske-e:exe:donu"
 
+    - path: "app/donu/ExposureSession.hs"
+      component: "aske-e:exe:donu"
+
     - path: "app/donu/HTML.hs"
       component: "aske-e:exe:donu"
 

--- a/jupyter/askee_kernel/kernel.json
+++ b/jupyter/askee_kernel/kernel.json
@@ -1,6 +1,3 @@
 {"argv":["python","-m","askeekernel", "-f", "{connection_file}"],
-  "display_name":"ASKE-E",
-  "env": {
-    "PYTHONPATH": "/home/jlamar/prj/aske-e/aske-e/jupyter/impl"
-  }
+  "display_name":"ASKE-E"
  }

--- a/jupyter/impl/askeekernel.py
+++ b/jupyter/impl/askeekernel.py
@@ -1,626 +1,70 @@
-from ipykernel.kernelbase import Kernel
+"""
+Implementation of the ASKE-E 'exposure' jupyter kernel.
+This kernel is a thin wrapper around the REPL endpoint provided by Donu.
+"""
+import re
 import json
-import csv
-import collections
-import os
-import requests
-from typing import List, Set, Dict, Tuple, Optional, Generator
-
-import antlr4
-from antlrgen.ASKEECommandVisitor import ASKEECommandVisitor
-from antlrgen.ASKEECommandParser import ASKEECommandParser
-from antlrgen.ASKEECommandLexer import ASKEECommandLexer
+from typing import Dict
 import traceback
-
-import unittest
+import requests
+from ipykernel.kernelbase import Kernel
 
 #------------------------------------------------------------------------------
 # Config
 #------------------------------------------------------------------------------
-
-donuAddress = "http://localhost:8000"
-vega_lite_schema = "https://vega.github.io/schema/vega-lite/v4.json"
-
-
-# -----------------------------------------------------------------------------
-#  AST
-# -----------------------------------------------------------------------------
-
-class AST:
-    pass
-
-class Expr(AST):
-    pass
-
-class ExprNumber(Expr):
-    def __init__(self, value:float):
-        self.value = value
-
-class ExprString(Expr):
-    def __init__(self, value:str):
-        self.value = value
-
-class ExprCall(Expr):
-    def __init__(self, name:str, args:List[Expr]):
-        self.functionName = name
-        self.args = args
-
-class ExprVar(Expr):
-    def __init__(self, name:str):
-        self.name = name
-
-class ExprList(Expr):
-    def __init__(self, elts:List[Expr]):
-        self.elts = elts
-
-class Stmt(AST):
-    pass
-
-class StmtAssign(Stmt):
-    def __init__(self, name:str, expr:Expr):
-        self.name = name
-        self.expr = expr
-
-class StmtEval(Stmt):
-    def __init__(self, expr:Expr):
-        self.expr = expr
-
-# -----------------------------------------------------------------------------
-#  Parser
-# -----------------------------------------------------------------------------
-
-class SyntaxError(Exception):
-    def __init__(self, errors):
-        self.errors = errors
-
-class ASKEECommandASTVisitor(ASKEECommandVisitor):
-    def identifier(self, ctx:antlr4.TerminalNode) -> str:
-        return ctx.getText()
-
-    def stringLit(self, ctx:antlr4.TerminalNode) -> str:
-        return ctx.getText().strip('"')
-
-    def number(self, ctx:antlr4.TerminalNode) -> float:
-        return float(ctx.getText())
-
-    def visitStmtAssign(self, ctx:ASKEECommandParser.StmtAssignContext) -> Stmt:
-        name = self.identifier(ctx.IDENTIFIER())
-        expr = self.visit(ctx.expr())
-        return StmtAssign(name, expr)
-
-    def visitStmtEval(self, ctx:ASKEECommandParser.StmtEvalContext) -> Stmt:
-        return StmtEval(self.visit(ctx.expr()))
-
-    def visitExprCall(self, ctx:ASKEECommandParser.ExprCallContext) -> Expr:
-        name = self.identifier(ctx.IDENTIFIER())
-        exprs = list([self.visit(expr) for expr in ctx.args])
-        return ExprCall(name, exprs)
-
-    def visitExprVar(self, ctx:ASKEECommandParser.ExprVarContext) -> Expr:
-        return ExprVar(self.identifier(ctx.IDENTIFIER()))
-
-    def visitExprString(self, ctx:ASKEECommandParser.ExprStringContext) -> Expr:
-        stripped = self.stringLit(ctx.STRING())
-        return ExprString(stripped)
-
-    def visitExprNumber(self, ctx:ASKEECommandParser.ExprNumberContext) -> Expr:
-        return ExprNumber(self.number(ctx.NUMBER()))
-
-    def visitExprList(self, ctx: ASKEECommandParser.ExprListContext):
-        exprs = list([self.visit(expr) for expr in ctx.args])
-        return ExprList(exprs)
-
-class ErrorCollector(antlr4.error.ErrorListener.ErrorListener):
-    def __init__(self):
-        self.syntaxErrors = []
-
-    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
-        self.syntaxErrors.append(f"{str(line)}:{str(column)} - Syntax error: {msg}")
-
-def parse_command(input: str) -> Stmt:
-    stream = antlr4.InputStream(input)
-    lexer = ASKEECommandLexer(stream)
-    tokstream = antlr4.CommonTokenStream(lexer)
-    errorCollector = ErrorCollector()
-    parser = ASKEECommandParser(tokstream)
-    parser.addErrorListener(errorCollector)
-    visitor = ASKEECommandASTVisitor()
-    stmt = parser.stmt()
-
-    if len(errorCollector.syntaxErrors) > 0:
-        raise SyntaxError(errorCollector.syntaxErrors)
-
-    return visitor.visit(stmt)
+DONU_ADDRESS = "http://localhost:8000"
 
 # -----------------------------------------------------------------------------
 # Donu client
 # -----------------------------------------------------------------------------
 
 class Donu:
+    """
+    Represents a Donu session
+    """
+    # pylint: disable=too-few-public-methods
     def __init__(self, addr:str):
+        self.sess = requests.Session()
         self.address = addr
 
-    @staticmethod
-    def modelTypeRNet():
-        return "reaction-net"
-
-    @staticmethod
-    def modelTypeESL():
-        return "easel"
-
-    @staticmethod
-    def modelTypeDEQ():
-        return "diff-eqs"
-
-    @staticmethod
-    def modelTypeLEQArr():
-        return "latex-eqnarray"
-
-    @staticmethod
-    def fileSource(fileName:str):
-        return {
-            "file": os.path.abspath(fileName)
-        }
-
-    def request(self, req):
-        response = requests.post(self.address, json.dumps(req))
-        if(response.status_code != 200):
-            raise Exception("Call to donu failed - response text: " + response.text)
-        return json.loads(response.text)
-
-    def decodeResponse(self, resp, why):
-        if resp['status'] == 'success':
-            return resp['result']
-
-        elif resp['status'] == 'error':
-            raise InterpreterError(why, resp['error'])
-
-        raise InterpreterError(why, f"[BUG] unexpected response status from Donu {resp['status']}")
-
-    def mk_model(self, model:str, type: str):
-        return {
-            "type": type,
-            "source": model
-        }
-
-    def deqSimulate(self, model: str, type: str, start: float, end: float, interval: float):
-        req = {
-            "command": "simulate",
-            "start": start,
-            "end": end,
-            "step": interval,
-            "definition": self.mk_model(model, type),
-        }
-
-        data = self.request(req)
-        vals = dict(data["values"])
-        vals["time"] = data["times"]
-        return ValueDataSeries(vals)
-
-    def checkModel(self, model: str, modelType: str, why: AST):
-        req = {
-            "command": "check-model",
-            "definition": self.mk_model(model, modelType)
-        }
-
-        self.decodeResponse(self.request(req), why)
-
-    def convertModel(self, model:str, srcType:str, dstType:str, why: AST) -> List[str]:
-        req = {
-            "command": "convert-model",
-            "definition": self.mk_model(model, srcType),
-            "dest-type": dstType
-        }
-
-        return self.decodeResponse(self.request(req), why)
-
-    def genCpp(self, model:str, srcType:str, why:AST) -> str:
-        req = {
-            "command": "generate-cpp",
-            "definition": self.mk_model(model, srcType),
-        }
-
-        return self.decodeResponse(self.request(req), why)
-
-    def stratifySpatial(self, model:str, connectionGraph:str, why:AST):
-        req = {
-            "command": "stratify-command",
-            "definition": model,
-            "connection-graph": Donu.fileSource(connectionGraph),
-            "stratification-type": "spatial",
-        }
-
-        return self.request(req)['raw-model']
-
-
-# -----------------------------------------------------------------------------
-# Interpreter
-# -----------------------------------------------------------------------------
-
-class InterpreterError(Exception):
-    def __init__(self, why: AST, message: str):
-        self.why = why
-        self.message = message
-
-class Value:
-    pass
-
-class ValueUnit(Value):
-    pass
-
-class ValueString(Value):
-    def __init__(self, value:str):
-        self.value = value
-
-class ValueCode(ValueString):
-    def __init__(self, value:str, language:str):
-        self.value = value
-        self.language = language
-
-class ValueNumber(Value):
-    def __init__(self, value:float):
-        self.value = value
-
-class ValueDataSeries(Value):
-    def __init__(self, data:Dict[str, List[float]]):
-        self.data = data
-
-class ValueModel(Value):
-    pass
-class ValueDiffeqModel(ValueModel):
-    def __init__(self, eqns:str):
-        self.source = eqns
-
-    @staticmethod
-    def getDonuType():
-        return Donu.modelTypeDEQ()
-
-class ValueESLModel(ValueModel):
-    def __init__(self, source:str):
-        self.source = source
-
-    @staticmethod
-    def getDonuType():
-        return Donu.modelTypeESL()
-
-class ValueRNetModel(ValueModel):
-    def __init__(self, source:str):
-        self.source = source
-
-    @staticmethod
-    def getDonuType():
-        return Donu.modelTypeRNet()
-
-class ValueLatexEqnArrayModel(ValueModel):
-    def __init__(self, source:str):
-        self.source = source
-
-    @staticmethod
-    def getDonuType():
-        return Donu.modelTypeLEQArr()
-
-class ASKEECommandInterpreter:
-    def __init__(self):
-        self.env = {}
-        self.unit = ValueUnit()
-        self.donu = Donu(donuAddress)
-
-        self.builtins = {
-            "loadCSV": self.loadCSV,
-            "loadDiffEq": self.loadDiffEq,
-            "plot": self.plot,
-            "simulateODE": self.simulate,
-            "loadESL": self.loadESL,
-            "loadLatexEqnArray": self.loadLatexEqnArray,
-            "loadReactionNet": self.loadReactionNet,
-            "asEquationSystem": self.asEquationSystem,
-            "asESL": self.asESL,
-            "generateSimulator": self.generateSimulator,
-            "save": self.saveAsFile,
-            "scatter":self.scatterPlot,
-            "stratifySpatial":self.stratifySpatial,
-            "asEqnArray":self.asEqnArray,
-        }
-
-    def stratifySpatial(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model, cgraph] = self.evalArgs(call, [ValueESLModel, ValueString], output)
-        stratResult = self.donu.stratifySpatial(model.source, cgraph.value, call)
-        return ValueString(stratResult)
-        # return ValueString(stratResult)
-
-
-    def scatterPlot(self, call:ExprCall, output:List[Dict]) -> Value:
-        [data, xaxisVal, yaxisVal] = self.evalArgs(call, [ValueDataSeries, ValueString, ValueString], output)
-        xaxis = xaxisVal.value
-        yaxis = yaxisVal.value
-        xs = data.data[xaxis]
-        ys = data.data[yaxis]
-        points = [{xaxis: xval, yaxis: yval} for (xval, yval) in zip(xs, ys) ]
-        chart = {
-            "$schema": vega_lite_schema,
-            "width": 800,
-            "height":600,
-            "description": "",
-            "data": {"values": points},
-            "mark": "point",
-            "encoding": {
-                "x": {"field": xaxis, "type": "quantitative", "scale": {"zero": False}},
-                "y": {"field": yaxis, "type": "quantitative", "scale": {"zero": False}}
-            }
-        }
-        self.outputChart(chart, output)
-        return self.unit
-
-    def asEqnArray(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model] = self.evalArgs(call, [ValueModel], output)
-        if isinstance(model, ValueLatexEqnArrayModel):
-            return model
-
-        eqn_model = self.donu.convertModel(model.source, model.getDonuType(), Donu.modelTypeLEQArr(), call)
-        return ValueLatexEqnArrayModel(eqn_model['source'])
-
-    # TODO: this should check that paths don't escape the jupyter env
-    def saveAsFile(self, call:ExprCall, output:List[Dict]) -> Value:
-        [path, value] = self.evalArgs(call, [ValueString, Value], output)
-        if isinstance(value, ValueString):
-            with open(path.value, "w") as handle:
-                handle.write(value.value)
-
-            return self.unit
-
-        self.fail("saving not implemented for this value -- yet", call)
-
-    def loadDiffEq(self, call:ExprCall, output:List[Dict]) -> Value:
-        [path] = self.evalArgs(call, [ValueString], output)
-        with open(path.value) as f:
-            return ValueDiffeqModel(f.read())
-
-    def simulate(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model, start, end, by] = self.evalArgs(call, [ValueModel, ValueNumber, ValueNumber, ValueNumber], output)
-        # XXX: overloading!
-        if isinstance(model, ValueESLModel):
-            return self.donu.deqSimulate(model.source, Donu.modelTypeESL(), start.value, end.value, by.value)
-
-        elif isinstance(model, ValueDiffeqModel):
-            return self.donu.deqSimulate(model.source, Donu.modelTypeDEQ(), start.value, end.value, by.value)
-
-    def loadCSV(self, call:ExprCall, output:List[Dict]) -> Value:
-        [filename] = self.evalArgs(call, [ValueString], output)
-        return self.loadSeriesFromFile(filename.value)
-
-    def loadESL(self, call:ExprCall, output:List[Dict]) -> Value:
-        [filename] = self.evalArgs(call, [ValueString], output)
-        return self.loadESLModelFromFile(filename.value, call)
-
-    def loadReactionNet(self, call:ExprCall, output:List[Dict]) -> Value:
-        [filename] = self.evalArgs(call, [ValueString], output)
-        return self.loadReactionNetFromFile(filename.value, call)
-
-    def loadLatexEqnArray(self, call:ExprCall, output:List[Dict]) -> Value:
-        [filename] = self.evalArgs(call, [ValueString], output)
-        with open(filename.value) as handle:
-            source = handle.read()
-            self.donu.checkModel(source, Donu.modelTypeLEQArr(), call)
-            return ValueLatexEqnArrayModel(source)
-
-    def asEquationSystem(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model] = self.evalArgs(call, [ValueModel], output)
-        if isinstance(model, ValueESLModel):
-            result = self.donu.convertModel(model.source, Donu.modelTypeESL(), Donu.modelTypeDEQ(), call)
-            return ValueDiffeqModel(result)
-
-        if isinstance(model, ValueLatexEqnArrayModel):
-            result = self.donu.convertModel(model.source, Donu.modelTypeLEQArr(), Donu.modelTypeDEQ(), call)
-            return ValueDiffeqModel(result)
-
-        elif isinstance(model, ValueESLModel):
-            return model
-
-        # TODO: a bit of a hack
-        elif isinstance(model, ValueRNetModel):
-            resultESL = self.donu.convertModel(model.source, Donu.modelTypeRNet(), Donu.modelTypeESL(), call)
-            result = self.donu.convertModel(resultESL, Donu.modelTypeESL(), Donu.modelTypeDEQ(), call)
-            return ValueDiffeqModel(result)
-
-        self.fail("Conversion not implemented", call)
-
-    def asESL(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model] = self.evalArgs(call, [Value], output)
-        if isinstance(model, ValueRNetModel):
-            result = self.donu.convertModel(model.source, Donu.modelTypeRNet(), Donu.modelTypeESL(), call)
-            return ValueESLModel(result)
-
-        elif isinstance(model, ValueESLModel):
-            return model
-
-    def generateSimulator(self, call:ExprCall, output:List[Dict]) -> Value:
-        [model] = self.evalArgs(call, [ValueESLModel], output)
-        sim = self.donu.genCpp(model.source, Donu.modelTypeESL(), call)
-        return ValueCode(sim, "C++")
-
-    def outputChart(self, chart, output):
-        msg = {
-            "application/vnd.vegalite.v4+json": chart,
-            "text/plain": "Plot could not be displayed"
-        }
-
-        output.append(msg)
-
-
-    def plot(self, call:ExprCall, output:List[Dict]):
-        [series, xaxis] = self.evalArgs(call, [ValueDataSeries, ValueString], output)
-        points = self.seriesVs(series, xaxis.value, call)
-        xyc = [{"x":x, "y":y, "c": c } for (x,y,c) in points]
-
-        chart = {
-            "$schema": vega_lite_schema,
-            "width": 800,
-            "height":600,
-            "description": "Plot [TODO: real description]",
-            "data": {"values": list(xyc)},
-            "mark": "line",
-            "encoding": {
-                "x": {"field": "x", "type": "quantitative"},
-                "y": {"field": "y", "type": "quantitative"},
-                "color": {"field": "c", "type": "nominal"}
-            }
-        }
-
-        self.outputChart(chart, output)
-
-        return self.unit
-
-
-    def fail(self, msg:str, why:AST) -> any:
-        raise InterpreterError(msg, why)
-
-    def getVar(self, nm:str, why:AST) -> Value:
-        if nm in self.env:
-            return self.env[nm]
-        else:
-            self.fail(f"Undefined variable '{nm}'", why)
-
-    def evalTo(self, expr: Expr, ty: type, output: List[Dict]) -> Value:
-        val = self.evalExpr(expr, output)
-        # self.outputString(f"evals to {val}", output)
-        if not isinstance(val, ty):
-            # better error message
-            self.fail("Expression has unexpected type", expr)
-        return val
-
-    def evalArgs(self, call:ExprCall, tys: List[type], output: List[Dict]) -> List[Value]:
-        if len(call.args) != len(tys):
-            self.fail(f"Function '{call.functionName}' called with {len(call.args)} arguments but takes {len(tys)}", call)
-
-        return list([self.evalTo(e, t, output) for (e, t) in zip(call.args, tys)])
-
-    def transpose(self, data):
-        maxrow = min([len(l) for l in data])
-        for row in range(0, maxrow):
-            yield [series[row] for series in data]
-
-    def mkTableRow(self, elts):
-        return "|" + "|".join([str(s) for s in elts]) + "|"
-
-    def seriesVs(self, data:ValueDataSeries, xaxis:str, why:AST) -> Generator[Tuple[float, float, str], None, None]:
-        if xaxis not in data.data:
-            self.fail(why, f"Data series has no field named '{xaxis}'")
-
-        for point in self.seriesAsPoints(data):
-            x = point[xaxis]
-            for (k, v) in point.items():
-                if k == xaxis:
-                    continue
-
-                yield (x, v, k)
-
-    def seriesAsPoints(self, data:ValueDataSeries) -> Generator[Dict[str, float], None, None]:
-        i = 0
-        while True:
-            point = collections.OrderedDict()
-            for (k, vals) in data.data.items():
-                if i < len(vals):
-                    point[k] = vals[i]
-                else:
-                    return
-
-            yield point
-            i = i + 1
-
-    def mkTable(self, headers, data):
-        hdrRow = self.mkTableRow(headers)
-        hdrSepRow = self.mkTableRow(["---" for _ in headers])
-        # TODO: quoting
-        rowsLst = [hdrRow, hdrSepRow] + [self.mkTableRow(row) for row in data]
-        return { "text/markdown": "\n".join(rowsLst), "text/plain": "table could not be displayed" }
-
-    def loadSeriesFromFile(self, filename:str) -> ValueDataSeries:
-        series = collections.OrderedDict()
-        with open(filename, newline='') as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                for k in row.keys():
-                    if k not in series:
-                        series[k] = []
-                    series[k].append(row[k])
-
-        return ValueDataSeries(series)
-
-    def loadESLModelFromFile(self, filename:str, why:AST) -> Value:
-        with open(filename, newline='') as f:
-            source = f.read()
-            self.donu.checkModel(source, Donu.modelTypeESL(), why)
-            return ValueESLModel(source)
-
-    def loadReactionNetFromFile(self, filename:str, why:AST) -> Value:
-        with open(filename, newline='') as f:
-            source = f.read()
-            self.donu.checkModel(source, Donu.modelTypeRNet(), why)
-            return ValueRNetModel(source)
-
-    def callFn(self, call:ExprCall, output:List[Dict]) -> Value:
-        if call.functionName in self.builtins:
-            return self.builtins[call.functionName](call, output)
-
-        self.fail(f"Unknown function '{call.functionName}'", call)
-
-    def outputString(self, string:str, output:List[Dict]):
-        output.append({ "text/plain": string })
-
-    def outputVal(self, value: Value, output:List[Dict]):
-        if value is ValueUnit:
-            return
-        elif isinstance(value, ValueString):
-            if isinstance(value, ValueCode):
-                aug_sim = "```C++\n" + value.value + "\n```\n"
-                output.append({"text/markdown": aug_sim, "text/plain": value.value })
-            else:
-                self.outputString(value.value, output)
-        elif isinstance(value, ValueNumber):
-            self.outputString(str(value.value), output)
-        elif isinstance(value, ValueDataSeries):
-            headers = value.data.keys()
-            rows = self.transpose(value.data.values())
-            output.append(self.mkTable(headers, rows))
-        elif isinstance(value, ValueDiffeqModel):
-            self.outputString(value.source, output)
-        elif isinstance(value, ValueESLModel):
-            self.outputString(value.source, output)
-        elif isinstance(value, ValueRNetModel):
-            self.outputString(value.source, output)
-        elif isinstance(value, ValueLatexEqnArrayModel):
-            output.append({"text/latex": value.source, "text/plain":value.source})
-
-    def evalExpr(self, expr:Expr, output: List[Dict]) -> Value:
-        if isinstance(expr, ExprNumber):
-            return ValueNumber(expr.value)
-        elif isinstance(expr, ExprString):
-            return ValueString(expr.value)
-        elif isinstance(expr, ExprVar):
-            return self.getVar(expr.name, expr)
-        elif isinstance(expr, ExprCall):
-            return self.callFn(expr, output)
-        else:
-            self.fail("Expression form not implemented", expr)
-
-    def evalStmt(self, stmt:Stmt, output:List[Dict]):
-        if isinstance(stmt, StmtAssign):
-            self.env[stmt.name] = self.evalExpr(stmt.expr, output)
-        elif isinstance(stmt, StmtEval):
-            val = self.evalExpr(stmt.expr, output)
-            self.outputVal(val, output)
-        else:
-            self.fail(f"Statement form not implemented: {stmt}", stmt)
-
-
-
-
-
+    def request(self, req:Dict) -> Dict:
+        """
+        POST a request to the connected Donu session.
+        req should conform to Donu's API
+        """
+        response = self.sess.post(self.address, json.dumps(req))
+        try:
+            return json.loads(response.text)
+        except Exception as ex:
+            raise Exception("Call to donu failed - response text: " + response.text) from ex
 # -----------------------------------------------------------------------------
 #  Kernel
 # -----------------------------------------------------------------------------
+def parse_code(code:str):
+    """
+    This returns the command that we should send to 'donu'. Normally this is just
+    'execute-exposure', but we might also be given a 'magic' to reset the REPL
+    state
+    """
+    cmd = None
+
+    if re.match(r'\%clear', code) is not None:
+        cmd = {
+            'command' : 'clear-exposure-state',
+        }
+    else:
+        cmd = {
+            'command' : 'execute-exposure-code',
+            'code': code
+        }
+
+    return cmd
 
 class ASKEEKernel(Kernel):
+    """
+    The kernel class
+    """
+    # pylint: disable=abstract-method
     implementation = 'ASKE-E'
     implementation_version = '1.0'
     language = 'no-op'
@@ -631,23 +75,21 @@ class ASKEEKernel(Kernel):
         'file_extension': '.txt',
     }
     banner = "ASKE-E Kernel - TODO (come up with a better name)"
+    donu   = Donu(DONU_ADDRESS)
 
-    interpreter = ASKEECommandInterpreter()
-
-    def outputErr(self, msg: str):
-        stream_content = {'name': 'stdout', 'text': msg}
-        self.send_response(self.iopub_socket, 'stream', stream_content)
-
-    def do_execute(self, code, silent, store_history=True, user_expressions=None,
+    def do_execute(self, code:str, silent:bool, store_history=True, user_expressions=None,
                    allow_stdin=False):
+        """
+        The main method we need to supply. This gets the user's code from a cell and evaluates it
+        by sending a request to Donu.
+        """
         try:
-            parsed = parse_command(code)
-            outputs = []
-            self.interpreter.evalStmt(parsed, outputs)
+            parsed = parse_code(code)
+            resp   = self.execute_donu_cmd(parsed)
+            output = { 'text/plain': resp }
 
             if not silent:
-                for output in outputs:
-                    self.send_response(self.iopub_socket, "display_data", {"data": output, "metadata": {}})
+                self.send_response(self.iopub_socket, "display_data", {"data": output, "metadata": {}})
 
             return {
                 'status': 'ok',
@@ -656,15 +98,29 @@ class ASKEEKernel(Kernel):
                 'user_expressions': {},
             }
 
-        except Exception as e:
-            tb = traceback.format_exc()
-            self.outputErr(tb)
+        except: # pylint: disable=bare-except
+            trace_back = traceback.format_exc()
+            self.output_err(trace_back)
             return {
                 'status': 'error',
                 'execution_count': self.execution_count,
                 'payload': [],
                 'user_expressions': {},
             }
+
+    def output_err(self, msg: str):
+        stream_content = {'name': 'stdout', 'text': msg}
+        self.send_response(self.iopub_socket, 'stream', stream_content)
+
+    def execute_donu_cmd(self, cmd):
+        if cmd is not None:
+            resp = self.donu.request(cmd)
+            if resp['status'] == 'success':
+                return resp['result']
+            if resp['status'] == 'error':
+                return ("Error: %s" % resp['error'])
+            raise Exception("Unexpected response status %s" % resp['status'])
+        return None
 
 if __name__ == '__main__':
     from ipykernel.kernelapp import IPKernelApp


### PR DESCRIPTION
- Adds a snaplet to Donu that manages sessions for use in Exposure. A session corresponds to a REPL interaction, and as such the session manager primarily maps each session to its current REPL state.
- Adds an addition Donu command for resetting an exposure session's state.
- Throws away most of the old Jupyter kernel in favor of sending exposure code to be interpreted by Donu.

This is just a rough initial implementation. Details such as precisely how timeouts/reclaiming old sessions should be handled can be revisited as necessary. Likewise, we will flesh out what information to return to the client (e.g. after evaluating a block of code) as the interpreter is developed.