### PR TITLE
Observe let-bound values during simulation

### DIFF
--- a/app/deca/Main.hs
+++ b/app/deca/Main.hs
@@ -45,6 +45,18 @@ main =
                 writeFile (replaceExtension out "gnuplot") $
                   A.gnuPlotScript res out
 
+        SimulateCPP start step stop ->
+          do  (modelFile, modelType) <- exactlyOne "model-like thing" $ modelsProvided opts
+              res <- A.simulateModelDiscrete modelType (A.FromFile modelFile) start stop step (seed opts)
+              let bs = A.dataSeriesAsCSV res
+                  out = outFile opts
+              if null out
+                then LBS.putStrLn bs
+                else LBS.writeFile out bs
+              when (gnuplot opts && not (null out)) $
+                writeFile (replaceExtension out "gnuplot") $
+                  A.gnuPlotScript res out
+
         ComputeError ->
           do  eqss <- mapM (A.loadDiffEqs . A.FromFile) (deqFiles opts)
               forM_ eqss \eqs ->

--- a/modelRepo/deq/sir.deq
+++ b/modelRepo/deq/sir.deq
@@ -1,8 +1,8 @@
-let beta = 0.4
-let gamma = 0.04
-let i_initial = 3.0
-let r_initial = 0.0
-let s_initial = 997.0
+param beta = 0.4
+param gamma = 0.04
+param i_initial = 3.0
+param r_initial = 0.0
+param s_initial = 997.0
 let total_population = S + I + R
 I(0) = i_initial
 R(0) = r_initial

--- a/modelRepo/deq/sir.deq
+++ b/modelRepo/deq/sir.deq
@@ -1,8 +1,8 @@
-param beta = 0.4
-param gamma = 0.04
-param i_initial = 3.0
-param r_initial = 0.0
-param s_initial = 997.0
+parameter beta = 0.4
+parameter gamma = 0.04
+parameter i_initial = 3.0
+parameter r_initial = 0.0
+parameter s_initial = 997.0
 let total_population = S + I + R
 I(0) = i_initial
 R(0) = r_initial

--- a/src/Language/ASKEE/CPP.hs
+++ b/src/Language/ASKEE/CPP.hs
@@ -18,19 +18,19 @@ import Language.ASKEE.Panic            ( panic )
 
 import Prettyprinter ( (<+>) )
 
-simulate :: 
-  Model -> 
+simulate ::
+  Model ->
   Double {- ^ start time -} ->
-  Double {- ^ end time -} -> 
-  Double {- ^ time step -} -> 
-  Maybe Int {- ^ seed -} -> 
+  Double {- ^ end time -} ->
+  Double {- ^ time step -} ->
+  Maybe Int {- ^ seed -} ->
   IO (DataSeries Double)
 simulate model start end step seed =
   do  let modelCPP = genModel model
           modelDriver = genDriver model start end step seed
           program = modelCPP <+> modelDriver
       res <- compileAndRun GCC [("model.cpp", program)]
-      points <- 
+      points <-
         case eitherDecode @[Map Text Double] (B.pack res) of
           Left err -> panic "simulateCPP" ["Couldn't decode C++-produced JSON", err, res]
           Right points' -> pure points'

--- a/src/Language/ASKEE/CPP/SimulatorGen.hs
+++ b/src/Language/ASKEE/CPP/SimulatorGen.hs
@@ -87,6 +87,9 @@ genExecStep mdl =
     [ C.declareInit C.auto (stateVarCurName v) (stateVarName v)
                                            | v <- Core.modelStateVars mdl ] ++
     [ C.switch "nextEvent" (mkCase <$> evts)
+    ] ++
+    [ C.assign (C.ident l) (genExpr rhs)
+    | (l, rhs) <- Map.toList (Core.modelLets mdl)
     ]
 
 
@@ -115,8 +118,8 @@ genNextStep evts =
                                                           | evt <- evts ] ++
 
     [ C.declareInit C.double "total_rate" (foldr1 (C.+) (effRateName <$> evts))
-    , C.ifThen 
-      ("total_rate" C.== C.doubleLit 0) 
+    , C.ifThen
+      ("total_rate" C.== C.doubleLit 0)
       [ C.returnWith (C.boolLit False) ]
     , C.declareInit C.auto "rate_dist"
         (C.callCon "std::uniform_real_distribution<double>"
@@ -168,15 +171,17 @@ genModel mdl
         ++ [ C.declareInit C.double (stateVarName v) (mkInit val)
            | (v,val) <- Map.toList (Core.modelInitState mdl')
            ]
-        
-        ++ [ C.declareInit C.double (stateVarName v) (C.doubleLit l)
-           | (v, Core.NumLit l) <- Map.toList (Core.modelLets mdl')]
+
+        ++ [ C.declareInit C.double (stateVarName v)
+                           (genExpr' stateVarName val)
+           | (v,val) <- Map.toList (Core.modelLets mdl')]
 
         ++ [ C.declareInit C.double timeName (C.doubleLit 0.0)
            , C.declare randEngineType rngName
            ]
 
-        ++ [ mkPrintFn [ v | v <- Core.modelStateVars mdl' ] ]
+        ++ [ mkPrintFn [ v | v <- Core.modelStateVars mdl'
+                          ++ Map.keys (Core.modelLets mdl') ] ]
     ]
   where
   mkInit = genExpr' \x -> panic "genModel"
@@ -207,16 +212,16 @@ genModel mdl
     [cout (C.stringLit "}")]
     where
       printV :: Core.Ident -> [C.Doc]
-      printV v = 
+      printV v =
         [ cout (quotedStrLit v)
         , cout (C.stringLit ":")
         , cout (C.ident v)
         ]
       quotedStrLit s = C.stringLit ("\\\"" <> s <> "\\\"")
-  
+
   cout s = C.stmt (C.ident "std::cout" C.<< s)
 
-  mdl' = (Core.inlineLets . Core.inlineParams) mdl
+  mdl' = Core.inlineParams mdl
 
 genExpr' :: Env -> Core.Expr -> C.Doc
 genExpr' vf e0 =
@@ -273,12 +278,12 @@ genExprSub f e =
   noparen = genExpr' f e
 
 
-genDriver :: 
-  Core.Model -> 
+genDriver ::
+  Core.Model ->
   Double {- ^ start time -} ->
-  Double {- ^ end time -} -> 
-  Double {- ^ time step -} -> 
-  Maybe Int {- ^ seed -} -> 
+  Double {- ^ end time -} ->
+  Double {- ^ time step -} ->
+  Maybe Int {- ^ seed -} ->
   C.Doc
 genDriver model start stop step seed = C.main
   [ C.declare (modelClassName model) cModel
@@ -294,11 +299,11 @@ genDriver model start stop step seed = C.main
 
   , C.while (cModelTime C.< cStart)
     [ C.assign cEventSelected (C.call (C.member cModel "next_event") [cModelEvent, cModelTime])
-    , C.ifThenElse 
-      cEventSelected 
+    , C.ifThenElse
+      cEventSelected
       [ C.stmt (C.call (C.member cModel "run_event") [cModelEvent, cModelTime]) ]
       [ cout "\"]\""
-      , C.returnWith (C.intLit 0) 
+      , C.returnWith (C.intLit 0)
       ]
     ]
 
@@ -306,11 +311,11 @@ genDriver model start stop step seed = C.main
 
   , C.while (cTargetTime C.< cStop C.&& cModelTime C.< cStop)
     [ C.assign cEventSelected (C.call (C.member cModel "next_event") [cModelEvent, cModelTime])
-    , C.ifThenElse 
-      cEventSelected 
+    , C.ifThenElse
+      cEventSelected
       [ C.stmt (C.call (C.member cModel "run_event") [cModelEvent, cModelTime]) ]
       [ C.break ]
-    , C.ifThenElse 
+    , C.ifThenElse
       (cModelTime C.< cTargetTime)
       [ C.continue ]
       [ cout "\",\""

--- a/src/Language/ASKEE/Core/Convert.hs
+++ b/src/Language/ASKEE/Core/Convert.hs
@@ -3,7 +3,7 @@
 module Language.ASKEE.Core.Convert where
 
 import qualified Data.Map      as Map
-import           Data.Maybe    ( mapMaybe, isNothing, fromJust )
+import           Data.Maybe    ( mapMaybe )
 
 import           Language.ASKEE.Core.Expr
 import qualified Language.ASKEE.Core.Expr         as Core
@@ -15,18 +15,16 @@ import           Language.ASKEE.DEQ.Syntax        ( DiffEqs(..) )
 
 asDiffEqs :: Model -> DiffEqs
 asDiffEqs mdl =
-  DiffEqs { deqParams  = Map.keys woInitCond
+  DiffEqs { deqParams  = modelParams mdl
           , deqInitial = modelInitState mdl
           , deqRates   = Map.mapWithKey stateEq (modelInitState mdl)
-          , deqLets    = modelLets mdl `Map.union` Map.map fromJust wInitCond
+          , deqLets    = modelLets mdl
           }
   where
   stateEq sv _ = simplifyExpr
                $ foldr (:+:) (NumLit 0)
                $ mapMaybe (eventTerm sv)
                $ modelEvents mdl
-
-  (woInitCond, wInitCond) = Map.partition isNothing (modelParams mdl)
 
 -- Eventually we may want to consider approaches to try to make guard
 -- continues (e.g., sigmoid?)

--- a/src/Language/ASKEE/Core/Syntax.hs
+++ b/src/Language/ASKEE/Core/Syntax.hs
@@ -43,7 +43,7 @@ data Event =
 
 
 modelStateVars :: Model -> [Ident]
-modelStateVars mdl = fst <$> Map.toList (modelInitState mdl)
+modelStateVars mdl = Map.keys (modelInitState mdl)
 
 isStateVar :: Ident -> Model -> Bool
 isStateVar x m = Map.member x (modelInitState m)
@@ -76,11 +76,11 @@ inlineLets m@Model{..} = m
 
 -- Multi-level parameter-inlining
 inlineParams :: Model -> Model
-inlineParams m@Model{..} = m 
+inlineParams m@Model{..} = m
   { modelEvents = substEvent <$> modelEvents
   , modelInitState = substExpr substitution <$> modelInitState
   , modelLets = substExpr substitution <$> modelLets
-  , modelParams = fmap (substExpr substitution) <$> modelParams 
+  , modelParams = fmap (substExpr substitution) <$> modelParams
   --  ^ chase down chains of parameter dependencies
   }
   where

--- a/src/Language/ASKEE/DEQ/GenLexer.x
+++ b/src/Language/ASKEE/DEQ/GenLexer.x
@@ -29,6 +29,7 @@ $digit = [0-9]
 tokens :-
 
 "let"    { atomic Let }
+"parameter" { atomic Parameter }
 -- "var"    { atomic Var }
 "d/dt"   { atomic DDt }
 "+"      { atomic Plus }

--- a/src/Language/ASKEE/DEQ/GenParser.y
+++ b/src/Language/ASKEE/DEQ/GenParser.y
@@ -4,6 +4,7 @@
 
 module Language.ASKEE.DEQ.GenParser where
 
+import           Data.Bifunctor ( Bifunctor(..) )
 import qualified Data.Map as Map
 import           Data.Maybe ( mapMaybe )
 import           Data.Text ( Text )
@@ -45,6 +46,7 @@ import Language.ASKEE.Panic                ( panic )
   true       { Located _ _ (Lexer.LitB $$) }
   false      { Located _ _ (Lexer.LitB $$) }
   let        { Located _ _ Lexer.Let }
+  parameter  { Located _ _ Lexer.Parameter }
 --  var        { Located _ _ Lexer.Var }
   ddt        { Located _ _ Lexer.DDt }
   REAL       { Located _ _ (Lexer.LitD $$) }
@@ -63,14 +65,16 @@ import Language.ASKEE.Panic                ( panic )
 Eqns                :: { DiffEqs }
   : Eqns1              { mkDiffEqs $1 }
 
-Eqns1               :: { [(EqnType, Ident, Expr)] }
+Eqns1               :: { [EqnDecl EqnType] }
   : Eqn                { [$1] }
   | Eqns1 Eqn          { $2 : $1}
 
-Eqn                 :: { (EqnType, Ident, Expr) }
-  : let SYM '=' Exp    { (Let, $2, $4) }
-  | SYM '(' REAL ')' '=' Exp    {% mkVar $1 $3 $6 }
-  | ddt SYM '=' Exp    { (Rate, $2, $4) }
+Eqn                       :: { EqnDecl EqnType }
+  : let SYM '=' Exp          { ($2, Let $4) }
+  | parameter SYM '=' Exp    { ($2, Parameter (Just $4)) }
+  | parameter SYM            { ($2, Parameter Nothing) }
+  | SYM '(' REAL ')' '=' Exp {% mkVar $1 $3 $6 }
+  | ddt SYM '=' Exp          { ($2, Rate $4) }
 
 Exp                 :: { Expr }
   : Exp '+' Exp        { Expr.Add $1 $3 }
@@ -94,8 +98,29 @@ Exp                 :: { Expr }
   | REAL               { Expr.LitD $1 }
 
 {
-data EqnType = Let | Init | Rate
+data EqnType
+  = Let Expr
+  | Init Expr
+  | Rate Expr
+  | Parameter (Maybe Expr)
   deriving Eq
+
+type EqnDecl rhs = (Ident, rhs)
+
+partitionEqnDecls :: [EqnDecl EqnType]
+                  -> ( [EqnDecl Expr]         -- let
+                     , [EqnDecl Expr]         -- init
+                     , [EqnDecl Expr]         -- rate
+                     , [EqnDecl (Maybe Expr)] -- parameter
+                     )
+partitionEqnDecls [] = ([], [], [], [])
+partitionEqnDecls ((i, eqnType):decls) =
+  let (lets, inits, rates, parameters) = partitionEqnDecls decls in
+  case eqnType of
+    Let e         -> ((i, e):lets,        inits,        rates,          parameters)
+    Init e        -> (       lets, (i, e):inits,        rates,          parameters)
+    Rate e        -> (       lets,        inits, (i, e):rates,          parameters)
+    Parameter mbE -> (       lets,        inits,        rates, (i, mbE):parameters)
 
 parseError :: [Located Lexer.Token] -> Either String a
 parseError [] =
@@ -103,23 +128,20 @@ parseError [] =
 parseError ((Located lin col t):ts) =
   Left $ "parse error at line "++show lin++", col "++show col++" ("++show t++")"
 
-mkVar :: Ident -> Double -> Expr -> Either String (EqnType, Ident, Expr)
+mkVar :: Ident -> Double -> Expr -> Either String (EqnDecl EqnType)
 mkVar i d e
-  | d == 0 = pure (Init, i, e)
+  | d == 0 = pure (i, Init e)
   | otherwise = Left $ "initial value for "++i'++" not declared as "++i'++"(0)"
 
   where
     i' = T.unpack i
 
-mkDiffEqs :: [(EqnType, Ident, Expr)] -> DiffEqs
+mkDiffEqs :: [EqnDecl EqnType] -> DiffEqs
 mkDiffEqs decls =
-  let deqLets    = Map.fromList $ mapMaybe (match Let)   decls
-      deqInitial = Map.fromList $ mapMaybe (match Init) decls
-      deqRates   = Map.fromList $ mapMaybe (match Rate)  decls
-      deqParams  = Map.empty
+  let (lets, inits, rates, parameters) = partitionEqnDecls decls
+      deqLets    = Map.fromList $ map (second expAsCore)        lets
+      deqInitial = Map.fromList $ map (second expAsCore)        inits
+      deqRates   = Map.fromList $ map (second expAsCore)        rates
+      deqParams  = Map.fromList $ map (second (fmap expAsCore)) parameters
   in  DiffEqs{..}
-
-  where
-    match s (s',i,e) = if s == s' then Just (i,expAsCore e) else Nothing
-
 }

--- a/src/Language/ASKEE/DEQ/GenParser.y
+++ b/src/Language/ASKEE/DEQ/GenParser.y
@@ -98,16 +98,16 @@ data EqnType = Let | Init | Rate
   deriving Eq
 
 parseError :: [Located Lexer.Token] -> Either String a
-parseError [] = 
+parseError [] =
   Left $ "parse error at end of file"
-parseError ((Located lin col t):ts) = 
+parseError ((Located lin col t):ts) =
   Left $ "parse error at line "++show lin++", col "++show col++" ("++show t++")"
 
 mkVar :: Ident -> Double -> Expr -> Either String (EqnType, Ident, Expr)
 mkVar i d e
   | d == 0 = pure (Init, i, e)
   | otherwise = Left $ "initial value for "++i'++" not declared as "++i'++"(0)"
-  
+
   where
     i' = T.unpack i
 
@@ -116,7 +116,7 @@ mkDiffEqs decls =
   let deqLets    = Map.fromList $ mapMaybe (match Let)   decls
       deqInitial = Map.fromList $ mapMaybe (match Init) decls
       deqRates   = Map.fromList $ mapMaybe (match Rate)  decls
-      deqParams  = []
+      deqParams  = Map.empty
   in  DiffEqs{..}
 
   where

--- a/src/Language/ASKEE/DEQ/Lexer.hs
+++ b/src/Language/ASKEE/DEQ/Lexer.hs
@@ -13,15 +13,16 @@ data Token = EOF
   | OpenP
   | CloseP
   | Let
+  | Parameter
   | DDt
   | If
   | Then
   | Else
-  | GT 
+  | GT
   | GTE
-  | EQ 
+  | EQ
   | LTE
-  | LT 
+  | LT
   | Not
   | And
   | Or

--- a/src/Language/ASKEE/DEQ/Print.hs
+++ b/src/Language/ASKEE/DEQ/Print.hs
@@ -19,6 +19,6 @@ printDiffEqs DiffEqs{..} = vcat [params, lets, initial, rates]
     initial = vcat $ map initBinding (toList deqInitial)
     rates   = vcat $ map (binding "d/dt") (toList deqRates)
 
-    paramBinding (i,mbE) = hsep ["param", text (unpack i), foldMap (\e -> hsep ["=", ppExpr e]) mbE]
+    paramBinding (i,mbE) = hsep ["parameter", text (unpack i), foldMap (\e -> hsep ["=", ppExpr e]) mbE]
     binding decl (i,e) = hsep [decl, text (unpack i), "=", ppExpr e]
     initBinding (i,e) = hsep [hcat [text (unpack i),parens (pretty (0::Int))], "=", ppExpr e]

--- a/src/Language/ASKEE/DEQ/Print.hs
+++ b/src/Language/ASKEE/DEQ/Print.hs
@@ -12,11 +12,13 @@ import Language.ASKEE.DEQ.Syntax ( DiffEqs(..) )
 import Prettyprinter ( hcat, hsep, vcat, parens, Pretty(pretty) )
 
 printDiffEqs :: DiffEqs -> Doc
-printDiffEqs DiffEqs{..} = vcat [lets, initial, rates]
+printDiffEqs DiffEqs{..} = vcat [params, lets, initial, rates]
   where
+    params  = vcat $ map paramBinding (toList deqParams)
     lets    = vcat $ map (binding "let") (toList deqLets)
     initial = vcat $ map initBinding (toList deqInitial)
     rates   = vcat $ map (binding "d/dt") (toList deqRates)
 
+    paramBinding (i,mbE) = hsep ["param", text (unpack i), foldMap (\e -> hsep ["=", ppExpr e]) mbE]
     binding decl (i,e) = hsep [decl, text (unpack i), "=", ppExpr e]
     initBinding (i,e) = hsep [hcat [text (unpack i),parens (pretty (0::Int))], "=", ppExpr e]

--- a/src/Language/ASKEE/DEQ/Syntax.hs
+++ b/src/Language/ASKEE/DEQ/Syntax.hs
@@ -20,7 +20,7 @@ import qualified Language.ASKEE.Core.Expr as CoreExpr
 
 -- | A system of differential equations.
 data DiffEqs = DiffEqs
-  { deqParams  :: [Ident]
+  { deqParams  :: Map Ident (Maybe Expr)
   , deqInitial :: Map Ident Expr
   , deqRates   :: Map Ident Expr      -- ^ These are the diff. eqns.
   , deqLets    :: Map Ident Expr
@@ -44,9 +44,9 @@ applyParams parameters = applyParams' parameters'
 applyParams' :: Map Ident Expr -> DiffEqs -> DiffEqs
 applyParams' su = dropParams . mapExprs (substExpr su)
   where
-  dropParams m = m { deqParams = [ x | x <- deqParams m
-                                     , not (x `Set.member` pSet) ] }
+  dropParams m = m { deqParams = Map.filterWithKey (\x _ -> not (x `Set.member` pSet))
+                                                   (deqParams m) }
   pSet = Map.keysSet su
 
-addParams :: [Ident] -> DiffEqs -> DiffEqs
+addParams :: Map Ident (Maybe Expr) -> DiffEqs -> DiffEqs
 addParams ps eqs = eqs { deqParams = ps }

--- a/src/Language/ASKEE/Latex/GenParser.y
+++ b/src/Language/ASKEE/Latex/GenParser.y
@@ -15,7 +15,7 @@ import Language.ASKEE.ESL.Convert      ( expAsCore )
 import Language.ASKEE.DEQ.Syntax       as Syntax
 import Language.ASKEE.Expr             as Expr
 import Language.ASKEE.ESL.Lexer        ( Located(..) )
-import Language.ASKEE.Latex.GenLexer  
+import Language.ASKEE.Latex.GenLexer
 import Language.ASKEE.Latex.Lexer      as Lexer
 import Language.ASKEE.Latex.Syntax
 }
@@ -63,7 +63,7 @@ Eqn                                       :: { (EqnType, Ident, Expr) }
   | SYM '=' Exp                              { (Let, $1, $3) }
   | SYMI '=' Exp                             { (Init, $1, $3) }
 
-Diff                                      :: { Ident }       
+Diff                                      :: { Ident }
   : 'd' SYM                                  { $2 }
   | SYM                                      {% fromDiff $1 }
 
@@ -98,13 +98,13 @@ fromDiff t
 
 mkInit :: Double -> Ident -> Expr -> Either String (EqnType, Ident, Expr)
 mkInit d i t
-  | d == 0 = pure (Init, i, t) 
+  | d == 0 = pure (Init, i, t)
   | otherwise = Left "only initial values at time = 0 are supported"
 
 parseError :: [Located Token] -> Either String a
-parseError [] = 
+parseError [] =
   Left $ "parse error at end of file"
-parseError ((Located lin col t):ts) = 
+parseError ((Located lin col t):ts) =
   Left $ "parse error at line "++show lin++", col "++show col++" ("++show t++")"
 
 mkDiffEqs :: [(EqnType, Ident, Expr)] -> Latex
@@ -112,8 +112,8 @@ mkDiffEqs decls =
   let deqLets    = Map.fromList $ mapMaybe (match Let) decls
       deqRates   = Map.fromList $ mapMaybe (match Rate) decls
       deqInitial = Map.fromList $ mapMaybe (match Init) decls
-      -- deqLets    = Map.difference lets deqRates 
-      deqParams  = []
+      -- deqLets    = Map.difference lets deqRates
+      deqParams  = Map.empty
   in  Latex DiffEqs{..}
 
   where

--- a/test/ASKEE.hs
+++ b/test/ASKEE.hs
@@ -5,6 +5,7 @@ module ASKEE ( tests ) where
 
 import qualified Data.FileEmbed as Embed
 import qualified Data.Map       as Map
+import qualified Data.Set       as Set
 import           Data.Text      ( Text, pack )
 import           Language.ASKEE
 import qualified Language.ASKEE.Core.Syntax        as Core
@@ -44,7 +45,7 @@ series1 =
 series2 :: DataSeries Double
 series2 =
   DataSeries { times = [0,30,60,90,120]
-             , values = Map.fromList 
+             , values = Map.fromList
                 [ ("I",[3,504.70103993445787,152.77443346245198,46.02318509849733,13.86300422788101])
                 , ("S",[997,2.0953177959873206,2.5090771953370807e-2,6.605341099589403e-3,4.418715256915984e-3])
                 , ("R",[0,493.2036422695545,847.2004757655942,953.9702095604024,986.1325770568615])
@@ -53,9 +54,9 @@ series2 =
 
 -- Generated via discrete event simulation using seed 123 at times [0,30..120]
 series3 :: DataSeries Double
-series3 = 
+series3 =
   DataSeries { times = [0.0,30.0428,60.2816,90.7133]
-             , values = Map.fromList 
+             , values = Map.fromList
                 [ ("I",[3.0,604.0,188.0,70.0])
                 , ("R",[0.0,361.0,812.0,930.0])
                 , ("S",[997.0,35.0,0.0,0.0])
@@ -93,7 +94,8 @@ assertDataClose actual expected =
   do  assertBool "Data series times are not close"
                  (and (zipWith isClose (times actual) (times expected)))
 
-      Map.keysSet (values expected) @=? Map.keysSet (values actual)
+      assertBool "Input data series value not a subset of the output data series"
+                 (Map.keysSet (values expected) `Set.isSubsetOf` Map.keysSet (values actual))
 
       -- TODO: maybe slightly better error messages
       assertBool  "Series data is not close"

--- a/test/ASKEE.hs
+++ b/test/ASKEE.hs
@@ -5,7 +5,6 @@ module ASKEE ( tests ) where
 
 import qualified Data.FileEmbed as Embed
 import qualified Data.Map       as Map
-import qualified Data.Set       as Set
 import           Data.Text      ( Text, pack )
 import           Language.ASKEE
 import qualified Language.ASKEE.Core.Syntax        as Core
@@ -38,6 +37,7 @@ series1 =
                 [ ("I",[3,570.9758710681082,177.87795797377797,53.663601453388395,16.17524903479719])
                 , ("S",[997,16.03663576555767,0.2688016239687885,7.747202089688689e-2,5.323898868597058e-2])
                 , ("R",[0,412.9874931663346,821.8532404022534,946.258926525715,983.771511976517])
+                , ("total_population",[1000,1000,1000,1000])
                 ]
              }
 
@@ -49,6 +49,7 @@ series2 =
                 [ ("I",[3,504.70103993445787,152.77443346245198,46.02318509849733,13.86300422788101])
                 , ("S",[997,2.0953177959873206,2.5090771953370807e-2,6.605341099589403e-3,4.418715256915984e-3])
                 , ("R",[0,493.2036422695545,847.2004757655942,953.9702095604024,986.1325770568615])
+                , ("total_population",[1000,1000,1000,1000])
                 ]
              }
 
@@ -60,6 +61,7 @@ series3 =
                 [ ("I",[3.0,604.0,188.0,70.0])
                 , ("R",[0.0,361.0,812.0,930.0])
                 , ("S",[997.0,35.0,0.0,0.0])
+                , ("total_population",[1000,1000,1000,1000])
                 ]
              }
 
@@ -94,8 +96,7 @@ assertDataClose actual expected =
   do  assertBool "Data series times are not close"
                  (and (zipWith isClose (times actual) (times expected)))
 
-      assertBool "Input data series value not a subset of the output data series"
-                 (Map.keysSet (values expected) `Set.isSubsetOf` Map.keysSet (values actual))
+      Map.keysSet (values expected) @=? Map.keysSet (values actual)
 
       -- TODO: maybe slightly better error messages
       assertBool  "Series data is not close"


### PR DESCRIPTION
Now that we distinguish `let`-bound values which do not depend on `state` (i.e., `param`s) from other forms of `let`-bound values, we can make ODE and discrete event simulation observe changes to the latter. This requires some mild refactoring to accomplish:

* The type of `deqParams` is now `Map Ident (Maybe Expr)` to mirror what is used in Core. Accordingly, we now pass on a Core model's `params` directly to `deqParams` during conversion. This requires adding some extra pretty-printing logic for `DiffEqs` to display the `deqParams` in order to make the test suite happy.

  Currently, the only way to obtain `deqParams` is by way of conversion from another form of model, as the parser does not yet support writing `param`s directly.
* The ODE and discrete event simulators no longer inline all `let`s, as we need to know the expressions used to create them.

Fixes #28.