### PR TITLE
Expose type information via metadata in `Core` interface description

### DIFF
--- a/aske-e.cabal
+++ b/aske-e.cabal
@@ -10,6 +10,7 @@ extra-source-files:  README.md
                    , modelRepo/easel/sir.easel
                    , modelRepo/easel/sir-no-parameters.easel
                    , modelRepo/deq/sir.deq
+                   , modelRepo/gromet-pnc/seir.json
 tested-with:         GHC == 8.8.4, GHC == 8.10.4
 
 library

--- a/src/Language/ASKEE/Core/Interface.hs
+++ b/src/Language/ASKEE/Core/Interface.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 module Language.ASKEE.Core.Interface where
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Data.List(foldl')
 
 import Language.ASKEE.Model.Basics
@@ -26,7 +28,7 @@ modelInterface Model{..} = ModelInterface
 
     toParam (x,mb) = Port
       { portName      = x
-      , portValueType = Real
+      , portValueType = maybe Real (read . Text.unpack . head) (meta x Map.!? "type")
       , portDefault   = VReal <$> mb
       , portMeta      = meta x
       }

--- a/src/Language/ASKEE/Core/Interface.hs
+++ b/src/Language/ASKEE/Core/Interface.hs
@@ -35,7 +35,7 @@ modelInterface Model{..} = ModelInterface
 
     toState x = Port
       { portName      = x
-      , portValueType = Real
+      , portValueType = maybe Real (read . Text.unpack . head) (meta x Map.!? "type")
       , portDefault   = Nothing
       , portMeta      = meta x
       }

--- a/src/Language/ASKEE/Gromet/Common.hs
+++ b/src/Language/ASKEE/Gromet/Common.hs
@@ -25,10 +25,10 @@ newtype JunctionUid = JunctionUid Uid
   deriving (Show, Eq, Ord)
 
 data ValueType =
-    Bool
+    Boolean
   | Real
   | Integer
-    deriving (Show,Eq)
+    deriving (Show, Eq)
 
 data Literal =
     LitReal    Double
@@ -81,7 +81,7 @@ instance JSON.ToJSON ValueType where
   toJSON ty =
     case ty of
       Real    -> "Real"
-      Bool    -> "Boolean"
+      Boolean -> "Boolean"
       Integer -> "Integer"
 
 -- We are being permissive here
@@ -92,8 +92,8 @@ instance JSON.FromJSON ValueType where
       "Float"     -> pure Real
       "T:Real"    -> pure Real
       "T:Float"   -> pure Real
-      "Boolean"   -> pure Bool
-      "T:Boolean" -> pure Bool
+      "Boolean"   -> pure Boolean
+      "T:Boolean" -> pure Boolean
       "Integer"   -> pure Integer
       "T:Integer" -> pure Integer
       _           -> fail ("Unknown VALUE_TYPE: " <> Text.unpack txt)
@@ -104,7 +104,7 @@ instance JSON.ToJSON Literal where
     case l of
       LitReal dbl   -> lit Real    (jsShow dbl)
       LitInteger i  -> lit Integer (jsShow i)
-      LitBool b     -> lit Bool    (jsShow b)
+      LitBool b     -> lit Boolean (jsShow b)
 
     where
     lit ty val = JSON.object [ "type"     .= ty
@@ -142,7 +142,7 @@ instance JSON.FromJSON Literal where
                Just n -> pure (LitInteger n)
                Nothing -> fail ("Invalid INTEGER_LITERAL: " <> Text.unpack txt)
 
-         Bool
+         Boolean
            | JSON.Bool b <- va -> pure (LitBool b)
            | JSON.String txt <- va ->
              if      Text.toLower txt == "true" then pure (LitBool True)

--- a/src/Language/ASKEE/Gromet/PetriNetClassic.hs
+++ b/src/Language/ASKEE/Gromet/PetriNetClassic.hs
@@ -185,7 +185,9 @@ pnToCore pn =
            | (x, s) <- ss
            , let uid     = jToName x
                  e       = Core.Var (initName x)
-                 theMeta = [ ("name", sName s) ]
+                 theMeta = [ ("name", sName s)
+                           , ("type", (Text.pack . show . sType) s)
+                           ]
            ]
 
   (rUID, coreEvs, eMeta) =

--- a/src/Language/ASKEE/Gromet/See.hs
+++ b/src/Language/ASKEE/Gromet/See.hs
@@ -27,7 +27,7 @@ instance PP ValueType where
   pp vt =
     case vt of
       Real    -> "real"
-      Bool    -> "bool"
+      Boolean -> "bool"
       Integer -> "integer"
 
 instance PP Port where

--- a/src/Language/ASKEE/Model/Basics.hs
+++ b/src/Language/ASKEE/Model/Basics.hs
@@ -14,7 +14,7 @@ data ValueType =
     Integer
   | Real
   | Boolean
-    deriving (Show,Read,Eq)
+    deriving (Show,Read,Eq,Ord)
 
 parseValueType :: Text -> Maybe ValueType
 parseValueType txt =

--- a/src/Language/ASKEE/Model/Basics.hs
+++ b/src/Language/ASKEE/Model/Basics.hs
@@ -13,8 +13,8 @@ import Data.Scientific(floatingOrInteger)
 data ValueType =
     Integer
   | Real
-  | Bool
-    deriving (Show,Eq)
+  | Boolean
+    deriving (Show,Read,Eq)
 
 parseValueType :: Text -> Maybe ValueType
 parseValueType txt =
@@ -22,8 +22,8 @@ parseValueType txt =
     "integer" -> pure Integer
     "real"    -> pure Real
     "float"   -> pure Real
-    "bool"    -> pure Bool
-    "boolean" -> pure Bool
+    "bool"    -> pure Boolean
+    "boolean" -> pure Boolean
     _         -> Nothing
 
 -- Note that these match Gromet
@@ -32,7 +32,7 @@ describeValueType vt =
   case vt of
     Integer -> "Integer"
     Real    -> "Real"
-    Bool    -> "Boolean"
+    Boolean -> "Boolean"
 
 
 

--- a/src/Language/ASKEE/Model/Interface.hs
+++ b/src/Language/ASKEE/Model/Interface.hs
@@ -14,7 +14,7 @@ import Language.ASKEE.Model.Basics
 data ModelInterface = ModelInterface
   { modelInputs   :: [ Port ]
   , modelOutputs  :: [ Port ]
-  } deriving Show
+  } deriving (Show, Eq, Ord)
 
 emptyModelInterface :: ModelInterface
 emptyModelInterface = ModelInterface { modelInputs = [], modelOutputs = [] }
@@ -25,7 +25,7 @@ data Port = Port
   , portValueType :: ValueType           -- ^ Type of values for this port
   , portDefault   :: Maybe Value         -- ^ Only for input ports
   , portMeta      :: Map Text [Text]     -- ^ Extra information
-  } deriving Show
+  } deriving (Show, Eq, Ord)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Descriptions of a `Core` model's interface currently declare all variables/initial conditions to have type `Real`. This is not generally correct. Instead, this PR causes interface description to look in a model's metadata for type information (for inputs and outputs alike), defaulting to `Real` when such information isn't present.

Also:
- Automatically propagate this type information in a common use case: conversion along the path `PetriNetClassic` -> `PetriNet` -> `Core`.
- Rename a `ValueType` constructor `Bool` -> `Boolean`, which more directly mirrors Gromet and `AlgebraicJulia` syntax.