### PR TITLE
Exposure: Add asEqnArray

### DIFF
--- a/app/donu/Schema.hs
+++ b/app/donu/Schema.hs
@@ -25,6 +25,7 @@ import           Language.ASKEE
 import           Language.ASKEE.ESL.Print (printModel)
 import           Language.ASKEE.Exposure.Syntax
 import qualified Language.ASKEE.Core.Syntax as Core
+import           Language.ASKEE.Latex.Print (printLatex)
 
 -------------------------------------------------------------------------------
 -- Input
@@ -535,6 +536,9 @@ instance JS.ToJSON DonuValue where
 
       VArray vs ->
         typed "array" (JS.toJSON (JS.toJSON . DonuValue <$> vs))
+
+      VLatex l ->
+        typedPrim "latex" $ show $ printLatex l
 
       VModel mdl          -> typedPrim "string" $ "<model " <> Core.modelName mdl <> ">"
       VModelExpr (EVal v) -> JS.toJSON (DonuValue v)

--- a/jupyter/src/Makefile
+++ b/jupyter/src/Makefile
@@ -1,0 +1,13 @@
+PIPENV_RUN=pipenv run
+
+reinstall:
+	${PIPENV_RUN} jupyter kernelspec uninstall -f askee_kernel || true
+	pipenv install
+	${PIPENV_RUN} jupyter kernelspec install askee_kernel --user
+
+.PHONY: lab
+lab:
+	${PIPENV_RUN} jupyter lab
+
+.PHONY: reinstall-lab
+reinstall-lab: reinstall lab

--- a/jupyter/src/askee_kernel/askeekernel.py
+++ b/jupyter/src/askee_kernel/askeekernel.py
@@ -192,6 +192,19 @@ def format_scatter(xlab, ylabs, xs, ysss):
     # }
     return out
 
+
+def format_latex(orig_latex):
+    """
+    Jupyter requires the LaTeX to be:
+
+    (1) Surrounded by $$ ... $$
+    (2) Using \\ to indicate newlines
+
+    This function performs surgery on ASKE-E–pretty-printed LaTeX to conform
+    to these requirements.
+    """
+    return "$$ \n" + ''.join(w+" \\\\\n" for w in orig_latex.splitlines()) + "$$"
+
 def format_resp_value(v):
     if isinstance(v, dict):
         ty = v['type']
@@ -217,6 +230,9 @@ def format_resp_value(v):
                                     float(val['max']),
                                     float(val['size']),
                                     val['bins'])
+
+        if ty == 'latex':
+            return { 'text/latex': format_latex(val) }
 
     return { 'text/plain': json.dumps(v) }
 

--- a/src/Language/ASKEE/DEQ/Syntax.hs
+++ b/src/Language/ASKEE/DEQ/Syntax.hs
@@ -25,7 +25,7 @@ data DiffEqs = DiffEqs
   , deqRates   :: Map Ident Expr      -- ^ These are the diff. eqns.
   , deqLets    :: Map Ident Expr
   }
-  deriving Show
+  deriving (Show, Eq, Ord)
 
 instance TraverseExprs DiffEqs where
   traverseExprs f DiffEqs { .. } =

--- a/src/Language/ASKEE/Exposure/Print.hs
+++ b/src/Language/ASKEE/Exposure/Print.hs
@@ -6,6 +6,7 @@ import qualified Data.Text.Lazy.Encoding as TL (decodeUtf8)
 import Language.ASKEE.Core.Print (ppModel, text)
 import Language.ASKEE.DataSeries (dataSeriesAsCSV)
 import Language.ASKEE.Exposure.Syntax
+import Language.ASKEE.Latex.Print (printLatex)
 import Prettyprinter
 
 ppValue :: Value -> Doc ()
@@ -15,6 +16,7 @@ ppValue v = case v of
   VBool b              -> if b then "true" else "false"
   VString s            -> viaShow s
   VModel m             -> ppModel m
+  VLatex l             -> printLatex l
   VArray vs            -> align $ list $ map ppValue vs
   VTimed v' t          -> ppValue v' <> "@time" <> pretty t
   VDataSeries ds       -> pretty $ TL.decodeUtf8 $ dataSeriesAsCSV ds

--- a/src/Language/ASKEE/Exposure/Syntax.hs
+++ b/src/Language/ASKEE/Exposure/Syntax.hs
@@ -7,6 +7,7 @@ import Data.Map(Map)
 
 import Language.ASKEE.DataSeries (DataSeries)
 import qualified Language.ASKEE.Core.Syntax as Core
+import Language.ASKEE.Latex.Syntax (Latex)
 
 type Ident  = Text
 data Stmt
@@ -40,6 +41,7 @@ data Value
   | VString Text
   | VDataSeries (DataSeries Double)
   | VModel Core.Model
+  | VLatex Latex
 
   | VTimed Value Double
   | VPoint (Map Text Value)
@@ -89,6 +91,7 @@ data FunctionName
   | FIn
   | FPlot
   | FScatter
+  | FAsEqnArray
   deriving (Show, Eq, Ord)
 
 data FunctionWithLambdaName
@@ -127,6 +130,7 @@ prefixFunctionName ident =
     "in"          -> Right FIn
     "plot"        -> Right FPlot
     "scatter"     -> Right FScatter
+    "asEqnArray"  -> Right FAsEqnArray
     strIdent  -> Left $ "Unsupported prefix function name: " ++ strIdent
 
 functionWithLambdaName :: Ident -> Either String FunctionWithLambdaName

--- a/src/Language/ASKEE/Latex/Syntax.hs
+++ b/src/Language/ASKEE/Latex/Syntax.hs
@@ -1,5 +1,6 @@
 module Language.ASKEE.Latex.Syntax where
-  
+
 import Language.ASKEE.DEQ.Syntax ( DiffEqs )
 
 newtype Latex = Latex { unLatex :: DiffEqs }
+  deriving (Show, Eq, Ord)


### PR DESCRIPTION
This adds (or rather, adds back) the `asEqnArray` function to Exposure. `asEqnArray` allows rendering models as LaTeX. A fair bit of refactoring was required to make the LaTeX conversion work again, but nothing too major.

Fixes #48.