### PR TITLE
Expose Simulation (via ODE) in Exposure

### DIFF
--- a/src/Language/ASKEE/Exposure/Print.hs
+++ b/src/Language/ASKEE/Exposure/Print.hs
@@ -17,6 +17,7 @@ ppValue v = case v of
   VString s            -> viaShow s
   VModel m             -> ppModel m
   VLatex l             -> printLatex l
+  VSampledData vs      -> align $ encloseSep "{ " " }" ", " $ map ppValue vs
   VArray vs            -> align $ list $ map ppValue vs
   VTimed v' t          -> ppValue v' <> "@time" <> pretty t
   VDataSeries ds       -> pretty $ TL.decodeUtf8 $ dataSeriesAsCSV ds

--- a/src/Language/ASKEE/Exposure/Syntax.hs
+++ b/src/Language/ASKEE/Exposure/Syntax.hs
@@ -42,6 +42,7 @@ data Value
   | VDataSeries (DataSeries Double)
   | VModel Core.Model
   | VLatex Latex
+  | VSampledData [Value] -- ^ list of samples
 
   | VTimed Value Double
   | VPoint (Map Text Value)

--- a/src/Language/ASKEE/Exposure/Syntax.hs
+++ b/src/Language/ASKEE/Exposure/Syntax.hs
@@ -79,6 +79,7 @@ data FunctionName
   | FOr
   | FProb
   | FSample
+  | FSimulate
   | FMin
   | FMax
   | FAt
@@ -123,6 +124,7 @@ prefixFunctionName ident =
     "mean"        -> Right FMean
     "interpolate" -> Right FInterpolate
     "sample"      -> Right FSample
+    "simulate"    -> Right FSimulate
     "min"         -> Right FMin
     "max"         -> Right FMax
     "histogram"   -> Right FHistogram


### PR DESCRIPTION
Closes #47 

Adds a SampledData data type, since those sorts of 2D arrays have special structure. This makes the implementation of `atPoints` a bit more clear as it needs to apply to the output of simulation and sampling.