### PR TITLE
Fix model fitting

### DIFF
--- a/src/Language/ASKEE/DEQ/Simulate.hs
+++ b/src/Language/ASKEE/DEQ/Simulate.hs
@@ -211,4 +211,10 @@ fitModel eqs ds scaled start =
         changes  = map change ps
     in \x -> transpose [ values pch Map.! x | pch <- changes ]
 
-  eqs' = addParams (Map.map (Just . NumLit) start) eqs
+
+  -- Transform the given eqs by specializing to all the parameters
+  -- that we're _not_ trying to fit, then add as parameters the params in
+  -- @start@
+  eqs' = addParams (Map.map (Just . NumLit) start) specialized
+  specialized  = specializeDiffEqs toSpecialize eqs
+  toSpecialize = Map.filterWithKey (\p _ -> Map.notMember p start) (getParams eqs mempty)


### PR DESCRIPTION
Deca's model fitting mode has broken. 

This change modifies the fitting function to specialize the given model on the parameters whose values we are _not_ trying to fit, leaving only the requested names as parameters.