### PR TITLE
Expose fitting in Exposure

### DIFF
--- a/app/donu/Schema.hs
+++ b/app/donu/Schema.hs
@@ -525,8 +525,8 @@ instance JS.ToJSON DonuValue where
       VSFold {}      -> unimplVal "<sfold>"
       VSuspended     -> unimplVal "<suspended>"
 
-      VSampledData{} -> tbd
-      VPoint{}       -> tbd
+      VSampledData{} -> unimplVal "<sampledData>"
+      VPoint m       -> typedPrim "point" (JS.toJSON . DonuValue <$> m)
 
     where
       typedPrim :: JS.ToJSON a => Text -> a -> JS.Value

--- a/src/Language/ASKEE/Exposure/Interpreter.hs
+++ b/src/Language/ASKEE/Exposure/Interpreter.hs
@@ -184,21 +184,11 @@ getVarValue i =
 
 bindTopLevelVar :: Ident -> Value -> Eval ()
 bindTopLevelVar i v =
-  do  mbV <- State.gets (Map.lookup i . envTopLevelVars)
-      case mbV of
-        Nothing ->
-          State.modify (\env -> env { envTopLevelVars = Map.insert i v (envTopLevelVars env) })
-        Just _ ->
-          throw ("variable " <> i <> " is already bound here")
+  State.modify (\env -> env { envTopLevelVars = Map.insert i v (envTopLevelVars env) })
 
 withLocalVar :: Ident -> Value -> Eval a -> Eval a
-withLocalVar i v thing =
-  do  localEnv    <- Reader.asks erLocalVars
-      topLevelEnv <- State.gets envTopLevelVars
-      case Map.lookup i localEnv <|> Map.lookup i topLevelEnv of
-        Nothing -> Reader.local (\er -> er { erLocalVars = Map.insert i v (erLocalVars er) }) thing
-        Just _ ->
-          throw ("variable " <> i <> " is already bound here")
+withLocalVar i v =
+  Reader.local (\er -> er { erLocalVars = Map.insert i v (erLocalVars er) })
 
 -------------------------------------------------------------------------------
 

--- a/src/Language/ASKEE/Exposure/Syntax.hs
+++ b/src/Language/ASKEE/Exposure/Syntax.hs
@@ -85,6 +85,7 @@ data FunctionName
   | FProb
   | FSample
   | FSimulate
+  | FFit
   | FMin
   | FMax
   | FAt
@@ -134,6 +135,7 @@ prefixFunctionName ident =
     "interpolate" -> Right FInterpolate
     "sample"      -> Right FSample
     "simulate"    -> Right FSimulate
+    "fit"         -> Right FFit
     "min"         -> Right FMin
     "max"         -> Right FMax
     "histogram"   -> Right FHistogram

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -207,10 +207,7 @@ tests =
             [ "x = 3.0"
             , "x = 5.0"
             , "x"
-            ] "x" $ \v ->
-            case v of
-              VDouble 5.0 -> pure ()
-              _ -> assertFailure "x not 5.0"
+            ] "x" $ \v -> v @?= VDouble 5.0
       , testCase "Param fitting (success)" $ do
           loadSirEaselExpr <- getLoadSirEaselExpr
           exprAssertionWithStmts

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -70,13 +70,18 @@ exprAssertionWithStmts stmtStrs actualExprStr k = do
 
 exprAssertionWithFailingStmts :: [String] -> String -> (Value -> Assertion) -> Assertion
 exprAssertionWithFailingStmts stmtStrs actualExprStr k = do
-  stmts      <- assertRightStr $ traverse lexAndParseStmt stmtStrs
   actualExpr <- assertRightStr $ lexAndParseExpr actualExprStr
-  (lr, env)  <- evalLoop emptyEvalRead initialEnv stmts
-  assertLeft lr
+  env        <- assertStmtsFail stmtStrs
   (errOrActualVal, _, _) <- runEval emptyEvalRead env $ interpretExpr actualExpr
   actualVal              <- assertRightText errOrActualVal
   k actualVal
+
+assertStmtsFail :: [String] -> IO Env
+assertStmtsFail stmtStrs = do
+  stmts      <- assertRightStr $ traverse lexAndParseStmt stmtStrs
+  (lr, env)  <- evalLoop emptyEvalRead initialEnv stmts
+  assertLeft lr
+  return env
 
 emptyEvalRead :: EvalRead
 emptyEvalRead = mkEvalReadEnv LBS.readFile LBS.writeFile

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -4,6 +4,7 @@ module Exposure (tests) where
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bifunctor (Bifunctor(..))
 import qualified Data.Text as Text
+import qualified Data.Map as Map
 import Data.Text (Text)
 import System.FilePath ((</>))
 import Test.Tasty.HUnit
@@ -13,7 +14,20 @@ import Language.ASKEE.Exposure.GenLexer (lexExposure)
 import Language.ASKEE.Exposure.GenParser (parseExposureExpr, parseExposureStmt)
 import Language.ASKEE.Exposure.Interpreter
 import Language.ASKEE.Exposure.Syntax
+
 import Paths_aske_e (getDataDir)
+import Language.ASKEE (DataSeries(..))
+
+series1 :: DataSeries Double
+series1 =
+  DataSeries { times = [0,30,60,90,120]
+             , values = Map.fromList
+                [ ("I",[3,570.9758710681082,177.87795797377797,53.663601453388395,16.17524903479719])
+                , ("S",[997,16.03663576555767,0.2688016239687885,7.747202089688689e-2,5.323898868597058e-2])
+                , ("R",[0,412.9874931663346,821.8532404022534,946.258926525715,983.771511976517])
+                , ("total_population",[1000,1000,1000,1000])
+                ]
+             }
 
 assertLeft :: Either a b -> IO ()
 assertLeft (Left _)  = pure ()
@@ -197,5 +211,15 @@ tests =
             case v of
               VDouble 5.0 -> pure ()
               _ -> assertFailure "x not 5.0"
+      , testCase "Param fitting (success)" $ do
+          loadSirEaselExpr <- getLoadSirEaselExpr
+          exprAssertionWithStmts
+            [ "sir = " <> loadSirEaselExpr
+            , "series = simulate(sir at [0..120 by 30])"
+            , "ps = fit(sir, series, \"i_initial\")"
+            ] "ps.values.I_initial" $ \val ->
+            case val of
+              VPoint _ -> pure ()
+              _ -> assertFailure "fit did not return a point"
       ]
     ]

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -188,5 +188,14 @@ tests =
       , testCase "String with whitespace" $ do
           exprAssertion "\"Hello World\"" $ \actualVal ->
             actualVal @?= VString "Hello World"
+      , testCase "Name shadowing" $ do
+          exprAssertionWithStmts
+            [ "x = 3.0"
+            , "x = 5.0"
+            , "x"
+            ] "x" $ \v ->
+            case v of
+              VDouble 5.0 -> pure ()
+              _ -> assertFailure "x not 5.0"
       ]
     ]

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -215,13 +215,20 @@ tests =
             ] "x" $ \v -> v @?= VDouble 5.0
       , testCase "Param fitting (success)" $ do
           loadSirEaselExpr <- getLoadSirEaselExpr
-          exprAssertionWithStmts
+          exprAssertion2WithStmts
             [ "sir = " <> loadSirEaselExpr
             , "series = simulate(sir at [0..120 by 30])"
             , "ps = fit(sir, series, \"i_initial\")"
-            ] "ps.values.I_initial" $ \val ->
-            case val of
-              VPoint _ -> pure ()
-              _ -> assertFailure "fit did not return a point"
+            ] "ps.values.i_initial" "ps.errors.i_initial" $ \val1 val2 ->
+            case (val1, val2) of
+              (VDouble _, VDouble _) -> pure ()
+              _ -> assertFailure "fit did not return a point with expected shape"
+      , testCase "Param fitting (failure)" $ do
+          loadSirEaselExpr <- getLoadSirEaselExpr
+          const () <$>
+            assertStmtsFail [ "sir = " <> loadSirEaselExpr
+                            , "series = simulate(sir at [0..120 by 30])"
+                            , "ps = fit(sir, series, \"I_initial\")"
+                            ]
       ]
     ]


### PR DESCRIPTION
Exposes a `fit` command that returns a pair of `(fit, errors)` where `fit, errors \in Name -> Double`.

ex:
```
champ> vals = fit(sir, obs, "I_init", "R_init")
champ> vals
champ> :e
{ ("errors", {("I_init", 0.6295261035539503), ("R_init", 42.1651590086165)})
, ("values", {("I_init", 0.872867739123043), ("R_init", -8.004777744930774)}) }
```
