### PR TITLE
Exposure: Allow specifying color schemes/ranges

### DIFF
--- a/app/donu/Schema.hs
+++ b/app/donu/Schema.hs
@@ -497,10 +497,11 @@ instance JS.ToJSON DonuValue where
                     , "vs_label" .= JS.toJSON xlab
                     ]
         where
-          go (PlotSeries label dat style _color) =
+          go (PlotSeries label dat style color) =
             JS.object [ "label" .= label
                       , "data"  .= JS.toJSON dat
                       , "style" .= JS.toJSON style
+                      , "color" .= JS.toJSON color
                       ]
 
       VSeries _ps -> unimplVal "<series>"

--- a/jupyter/src/askee_kernel/askeekernel.py
+++ b/jupyter/src/askee_kernel/askeekernel.py
@@ -180,13 +180,22 @@ def format_plot(title, series, vs, vs_label):
                           s['label']: s['data'][vi],
                           'series': s['label'] })
 
-    layers = [ { "mark": s['style'],
-                 "encoding": {
-                     "x": {"field": vs_label, "type": "quantitative"},
-                     "y": {"field": s['label'], "type": "quantitative"},
-                     "color": {"field": "series", "type": "nominal"}
-                 }
-                } for s in series ]
+    layers = []
+    for s in series:
+        layer_color = {"field": "series", "type": "nominal"}
+        series_color = s['color']
+        if isinstance(series_color, str):
+            layer_color['scale'] = {'scheme': series_color}
+        elif isinstance(series_color, list):
+            layer_color['scale'] = {'range': series_color}
+
+        layers.append({ "mark": s['style'],
+                        "encoding": {
+                            "x": {"field": vs_label, "type": "quantitative"},
+                            "y": {"field": s['label'], "type": "quantitative"},
+                            "color": layer_color
+                        }
+                      })
 
     out = {
         'application/vnd.vegalite.v4+json': {

--- a/src/Language/ASKEE/Exposure/Interpreter.hs
+++ b/src/Language/ASKEE/Exposure/Interpreter.hs
@@ -624,13 +624,26 @@ interpretSeries vs label opts =
        { Plot.plotSeriesLabel = label
        , Plot.plotSeriesData  = vs'
        , Plot.plotSeriesStyle = style
-       , Plot.plotColor       = Nothing
+       , Plot.plotColor       = color
        }
   where
     style =
       case Map.lookup "style" opts of
         Just (VString s) -> interpStyle $ CI.mk s
         _                -> Plot.Line
+
+    color =
+      case Map.lookup "color" opts of
+        Just (VString s)
+          -> Just $ Plot.ColorScheme $ CI.foldedCase $ CI.mk s
+        Just (VArray arr)
+          |  Just range <- traverse asString arr
+          -> Just $ Plot.ColorRange range
+        _ -> Nothing
+
+    asString :: Value -> Maybe Text
+    asString (VString s) = Just s
+    asString _           = Nothing
 
     interpStyle :: CI Text -> PlotStyle
     interpStyle "points"  = Plot.Points

--- a/src/Language/ASKEE/Exposure/Plot.hs
+++ b/src/Language/ASKEE/Exposure/Plot.hs
@@ -20,7 +20,7 @@ data PlotSeries a = PlotSeries
   { plotSeriesLabel :: Text
   , plotSeriesData  :: a
   , plotSeriesStyle :: PlotStyle
-  , plotColor       :: Maybe Text
+  , plotColor       :: Maybe PlotColor
   }
   deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -31,8 +31,21 @@ data PlotStyle
   | Line
   deriving (Show, Eq, Ord, Generic, NFData)
 
+data PlotColor
+  = ColorScheme Text
+    -- ^ A color scheme, as described in
+    --   <https://vega.github.io/vega/docs/schemes/>.
+  | ColorRange [Text]
+    -- ^ A range of colors, as described in
+    --   <https://vega.github.io/vega-lite/docs/scale.html#2-setting-the-range-property-to-an-array-of-valid-css-color-strings>.
+  deriving (Show, Eq, Ord, Generic, NFData)
+
 instance JS.ToJSON PlotStyle where
   toJSON Points  = "point"
   toJSON Circles = "circle"
   toJSON Squares = "square"
   toJSON Line    = "line"
+
+instance JS.ToJSON PlotColor where
+  toJSON (ColorScheme scheme) = JS.toJSON scheme
+  toJSON (ColorRange range)   = JS.toJSON range


### PR DESCRIPTION
Vega-Lite has a dizzying array of color options. For now, we allow specifying
colors in one of two ways:

* A color scheme, which is a predefined, named set of colors to alternate between. These are represented as strings.
* A color range, which is a user-defined set of colors to alternate between. These are represented as arrays of strings.

Fixes #91.