### PR TITLE
`fit` changes

### DIFF
--- a/src/Language/ASKEE/DEQ/Simulate.hs
+++ b/src/Language/ASKEE/DEQ/Simulate.hs
@@ -194,6 +194,7 @@ fitModel eqs ds scaled start =
 
   dt            = [ (x,(vs,s))
                   | (x,vs) <- Map.toList (values ds)
+                  , Map.member x (deqRates eqs')
                   , let s = case Map.lookup x scaled of
                               Nothing -> 1
                               Just m  -> 1 / m

--- a/src/Language/ASKEE/Exposure/Interpreter.hs
+++ b/src/Language/ASKEE/Exposure/Interpreter.hs
@@ -295,8 +295,8 @@ interpretCall fun args =
         _ -> typeError "simulate expects a fold as its argument"
     FFit         ->
       case args of
-        (m:series:params) ->
-          interpretFit m series params
+        [m,VPoint datas,VArray params] ->
+          interpretFit m datas params
         _ ->
           typeError "fit expects a model, a data series, and a sequence of parameter names"
     FAt          ->
@@ -627,11 +627,18 @@ interpretSeries vs label opts =
     interpStyle "Line"    = Plot.Line
     interpStyle _         = Plot.Line
 
-interpretFit :: Value -> Value -> [Value] -> Eval Value
+interpretFit :: Value -> Map Text Value -> [Value] -> Eval Value
 interpretFit mv ds ps =
   do m   <- Model.Core <$> model mv
      ps' <- traverse str ps
-     ds' <- timedPointsAsSeries =<< array value ds
+     ds' <- traverse (array double) ds
+     dataSeries <-
+       case Map.lookup "time" ds' of
+         Nothing ->
+           throw "fit() data requires a 'time' series"
+         Just ts ->
+           let rest = Map.delete "time" ds'
+           in pure $ DS.DataSeries ts rest
      case Model.toDeqs m of
        Left err ->
          throw $ Text.pack err
@@ -640,7 +647,7 @@ interpretFit mv ds ps =
                 ifaceErrs = A.paramsNotExistErrors (Set.fromList ps') iface
             case ifaceErrs of
               [] ->
-                do let (res, _) = DEQ.fitModel deq ds' mempty $ Map.fromList (zip ps' (repeat 0))
+                do let (res, _) = DEQ.fitModel deq dataSeries mempty $ Map.fromList (zip ps' (repeat 0))
                        vals = VPoint $ Map.map (VDouble . fst) res
                        errs = VPoint $ Map.map (VDouble . snd) res
                    return $ VPoint $ Map.fromList [ ("values", vals), ("errors", errs) ]

--- a/test/ASKEE.hs
+++ b/test/ASKEE.hs
@@ -59,6 +59,17 @@ series1' =
                 ]
              }
 
+series1Extra :: DataSeries Double
+series1Extra =
+  DataSeries { times = [0,30,60,90,120]
+             , values = Map.fromList
+                [ ("I",[3,570.9758710681082,177.87795797377797,53.663601453388395,16.17524903479719])
+                , ("S",[997,16.03663576555767,0.2688016239687885,7.747202089688689e-2,5.323898868597058e-2])
+                , ("R",[0,412.9874931663346,821.8532404022534,946.258926525715,983.771511976517])
+                , ("E",[0,1,2,3,4])
+                ]
+             }
+
 -- Generated via GSL simulation with beta=0.5
 series2 :: DataSeries Double
 series2 =
@@ -293,6 +304,11 @@ tests =
                                   , ("gamma", (0.02, 0.06))
                                   ]
                                   series1'
+    , testCase "Basic parameter fitting (extra data)" $
+        testFitParam (Inline sir) [ ("s_initial", (995.0, 1000.0))
+                                  , ("gamma", (0.02, 0.06))
+                                  ]
+                                  series1Extra
     , testCase "Basic SIR discrete event simulation test" $ testSimulateEslDiscrete (Inline sirSansParameters) 0 120 30 series3
     , testCase "State-to-state flow schematic" $ testAsSchematicGraph s2s
     , testCase "State-to-event flow schematic" $ testAsSchematicGraph s2e

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -215,7 +215,11 @@ tests =
           exprAssertion2WithStmts
             [ "sir = " <> loadSirEaselExpr
             , "series = simulate(sir at [0..120 by 30])"
-            , "ps = fit(sir, series, \"i_initial\")"
+            , "T = time(series)"
+            , "vs = value(series)"
+            , "ps = fit(sir, "
+                    ++ "{{time=T, S=vs.S, I=vs.I, R=vs.R}}, "
+                    ++ "[\"i_initial\"])"
             ] "ps.values.i_initial" "ps.errors.i_initial" $ \val1 val2 ->
             case (val1, val2) of
               (VDouble _, VDouble _) -> pure ()
@@ -223,10 +227,15 @@ tests =
       , testCase "Param fitting (failure)" $ do
           loadSirEaselExpr <- getLoadSirEaselExpr
           const () <$>
-            assertStmtsFail [ "sir = " <> loadSirEaselExpr
-                            , "series = simulate(sir at [0..120 by 30])"
-                            , "ps = fit(sir, series, \"I_initial\")"
-                            ]
+            assertStmtsFail
+            [ "sir = " <> loadSirEaselExpr
+            , "series = simulate(sir at [0..120 by 30])"
+            , "T = time(series)"
+            , "vs = value(series)"
+            , "ps = fit(sir, "
+                    ++ "{{time=T, S=vs.S, I=vs.I, R=vs.R}}, "
+                    ++ "[\"I_initial\"])"
+            ]
       , testCase "Join (bad model args)" $ do
           loadSirEaselExpr <- getLoadSirEaselExpr
           void $ assertStmtsFail


### PR DESCRIPTION
+ Interface change for exposure's `fit`
+ Ignore unneeded data in `L.A.DEQ.Simulate.fitModel`
+ Call `panic` rather than relying on `Map.!` when looking keys up in `L.A.DEQ.Simulate`