### PR TITLE
Catch exceptions when reading/writing files that don't exist

### DIFF
--- a/app/donu/ExposureSession.hs
+++ b/app/donu/ExposureSession.hs
@@ -101,7 +101,7 @@ exposureServerLoop c = go Exposure.initialEnv
 
 -- | The implementation of @getFileFn@ for Exposure. This implementation sends a
 -- message to the client to fetch a file.
-readClientFile :: Connection -> FilePath -> IO (Either Text.Text LBS.ByteString)
+readClientFile :: Connection -> Exposure.EvalReadFileFn
 readClientFile c f =
   do sendTextData c (ReadFile f)
      msg <- receiveData c
@@ -116,7 +116,7 @@ readClientFile c f =
 
 -- | The implementation of @getFileFn@ for Exposure. This implementation sends a
 -- message to the client to fetch a file.
-writeClientFile :: Connection -> FilePath -> LBS.ByteString -> IO (Either Text.Text ())
+writeClientFile :: Connection -> Exposure.EvalWriteFileFn
 writeClientFile c f bs =
   do sendTextData c (WriteFile f bs)
      msg <- receiveData c

--- a/app/donu/ExposureSession.hs
+++ b/app/donu/ExposureSession.hs
@@ -85,6 +85,10 @@ exposureServerLoop c = go Exposure.initialEnv
           -- This is the toplevel, so we don't expect any filecontents
           do sendTextData c (Failure "Unexpected FileContents message")
              return env
+        WroteFile{} ->
+          -- This is the toplevel, so we don't expect any WroteFiles
+          do sendTextData c (Failure "Unexpected WroteFile message")
+             return env
         Error err ->
           do sendTextData c $ Failure $ TL.toStrict $ TL.decodeUtf8 err
              return env

--- a/jupyter/src/askee_kernel/askeekernel.py
+++ b/jupyter/src/askee_kernel/askeekernel.py
@@ -57,12 +57,22 @@ def exposure_protocol(app, req_q, resp_q, to_kernel_q):
             resp = json.loads(resp_q.get())
 
             if resp['type'] == 'read-file':
-                with open(resp['path']) as f:
-                    app.send(json.dumps({'type':'file-contents', 'contents': f.read()}))
+                try:
+                    with open(resp['path']) as f:
+                        app.send(json.dumps({'type':'file-contents', 'contents': f.read()}))
+                except FileNotFoundError:
+                    app.send(json.dumps({'type':'error', 'message': 'File not found'}))
+                except Exception as e:
+                    app.send(json.dumps({'type':'error', 'message': str(e)}))
 
             elif resp['type'] == 'write-file':
-                with open(resp['path'], 'w+') as f:
-                    f.write(resp['contents'])
+                try:
+                    with open(resp['path'], 'w+') as f:
+                        f.write(resp['contents'])
+                except FileNotFoundError:
+                    app.send(json.dumps({'type':'error', 'message': 'File not found'}))
+                except Exception as e:
+                    app.send(json.dumps({'type':'error', 'message': str(e)}))
 
             elif resp['type'] == 'success':
                 break

--- a/src/Language/ASKEE/Exposure/Interpreter.hs
+++ b/src/Language/ASKEE/Exposure/Interpreter.hs
@@ -147,9 +147,9 @@ data EvalRead = EvalRead
   , erGetFileFn   :: EvalReadFileFn
   }
 
-type EvalReadFileFn  = FilePath -> IO (Either Text LBS.ByteString)
-type EvalWriteFileFn = FilePath -> LBS.ByteString -> IO (Either Text ())
-
+type EvalIO a        = IO (Either Text a) -- ^ Either an error message or the value
+type EvalReadFileFn  = FilePath -> EvalIO LBS.ByteString
+type EvalWriteFileFn = FilePath -> LBS.ByteString -> EvalIO ()
 
 mkEvalReadEnv :: EvalReadFileFn -> EvalWriteFileFn -> EvalRead
 mkEvalReadEnv rd wr = EvalRead


### PR DESCRIPTION
The ASKE-E kernel happily dies if a program requests a file that does not exist, and the Donu session is none the wiser. This change adds more graceful error handling:
+ Catch exceptions in the Python ASKE-E kernel
+ Check for client errors in the WebSockets Exposure protocol after reading/writing