### PR TITLE
Add expression indexing to exposure

### DIFF
--- a/src/Language/ASKEE/Exposure/GenParser.y
+++ b/src/Language/ASKEE/Exposure/GenParser.y
@@ -107,6 +107,7 @@ expr : IDENT                            { EVar $1 }
                                               ; pure (ECallWithLambda funName $3 $6 $8) }}
      | infixExpr                        { $1 }
      | expr '.' IDENT                   { EMember $1 $3 }
+     | expr '[' expr ']'                { EIndex $1 $3 }
      | '[' commaSepExprs0 ']'           { EList $2 }
      | '[' expr '..' expr 'by' expr ']' { EListRange $2 $4 $6 }
      | '{{' pointBinds0 '}}'            { EPoint $2 }

--- a/src/Language/ASKEE/Exposure/Syntax.hs
+++ b/src/Language/ASKEE/Exposure/Syntax.hs
@@ -35,6 +35,7 @@ data Expr
   | ECall FunctionName [Expr]
   | ECallWithLambda FunctionWithLambdaName [Expr] Ident Expr
   | EMember Expr Ident
+  | EIndex Expr Expr
   | EList [Expr]
   | EListRange Expr Expr Expr
   | EPoint [(Ident, Expr)]

--- a/test/Exposure.hs
+++ b/test/Exposure.hs
@@ -332,6 +332,27 @@ makeTests =
             case v of
               VArray vs -> traverse_ assertDouble vs
               _         -> failure
+      , testCase "Expression indexing" $ do
+          loadSirEaselExpr <- getLoadSirEaselExpr
+
+          exprAssertion "[0.0, 1.0][1]" $ \v ->
+            v @?= VDouble 1.0
+
+          exprAssertionWithStmts
+            [ "sir = " <> loadSirEaselExpr ]
+            "simulate(sir[\"I\"] at 1.0)" $ \v ->
+            case v of
+              VDouble _ -> pure ()
+              _ -> assertFailure "Simulate of indexed expr returned wrong type"
+
+          exprAssertionWithStmts
+            [ "sir = " <> loadSirEaselExpr
+            , "r = simulate(sir at 1.0)"
+            ] "r[\"I\"]" $ \v ->
+            case v of
+              VDouble _ -> pure ()
+              _ -> assertFailure "Index of simulate returned wrong type"
+
 
       , testCase "Load missing files" $ do
           void $ assertStmtsFail ["loadCSV(\"path/to/nothing.csv\")"]


### PR DESCRIPTION
Add `e[e]` to exposure, i.e. to index lists: `[0,1,2][1]` and also models `m["A weird state variable name"]`.